### PR TITLE
refactor: [#107] centralize UserOutput via dependency injection

### DIFF
--- a/src/bootstrap/app.rs
+++ b/src/bootstrap/app.rs
@@ -27,8 +27,9 @@ use crate::{bootstrap, presentation};
 /// This function serves as the application bootstrap, handling:
 /// 1. CLI argument parsing (delegated to presentation layer)
 /// 2. Logging initialization using `LoggingConfig`
-/// 3. Command execution (delegated to presentation layer)
-/// 4. Error handling and exit code management
+/// 3. Service container creation for dependency injection
+/// 4. Command execution (delegated to presentation layer)
+/// 5. Error handling and exit code management
 ///
 /// # Panics
 ///
@@ -54,10 +55,15 @@ pub fn run() {
         "Application started"
     );
 
+    // Initialize service container for dependency injection
+    let container = bootstrap::Container::new();
+
     match cli.command {
         Some(command) => {
-            if let Err(e) = presentation::execute(command, &cli.global.working_dir) {
-                presentation::handle_error(&e);
+            if let Err(e) =
+                presentation::execute(command, &cli.global.working_dir, &container.user_output())
+            {
+                presentation::handle_error(&e, &container.user_output());
                 std::process::exit(1);
             }
         }

--- a/src/bootstrap/container.rs
+++ b/src/bootstrap/container.rs
@@ -1,0 +1,103 @@
+//! Application Service Container
+//!
+//! This module provides centralized initialization of application-wide services
+//! that need consistent configuration across the entire application.
+
+use std::sync::{Arc, Mutex};
+
+use crate::presentation::commands::constants::DEFAULT_VERBOSITY;
+use crate::presentation::user_output::UserOutput;
+
+/// Application service container
+///
+/// Holds shared services initialized during application bootstrap.
+/// Services are wrapped in `Arc<Mutex<T>>` for thread-safe shared ownership
+/// with interior mutability across the application.
+///
+/// # Example
+///
+/// ```rust
+/// use torrust_tracker_deployer_lib::bootstrap::container::Container;
+///
+/// let container = Container::new();
+/// let user_output = container.user_output();
+/// user_output.lock().unwrap().success("Operation completed");
+/// ```
+#[derive(Clone)]
+pub struct Container {
+    user_output: Arc<Mutex<UserOutput>>,
+}
+
+impl Container {
+    /// Create a new container with initialized services
+    ///
+    /// Uses `DEFAULT_VERBOSITY` for user output. In the future, this may
+    /// accept a verbosity parameter from CLI flags.
+    #[must_use]
+    pub fn new() -> Self {
+        let user_output = Arc::new(Mutex::new(UserOutput::new(DEFAULT_VERBOSITY)));
+
+        Self { user_output }
+    }
+
+    /// Get shared reference to user output service
+    ///
+    /// Returns an `Arc<Mutex<UserOutput>>` that can be cheaply cloned and shared
+    /// across threads and function calls. Lock the mutex to access the user output.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use torrust_tracker_deployer_lib::bootstrap::container::Container;
+    ///
+    /// let container = Container::new();
+    /// let user_output = container.user_output();
+    /// user_output.lock().unwrap().success("Operation completed");
+    /// ```
+    #[must_use]
+    pub fn user_output(&self) -> Arc<Mutex<UserOutput>> {
+        Arc::clone(&self.user_output)
+    }
+}
+
+impl Default for Container {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_should_create_container_with_user_output() {
+        let container = Container::new();
+        let user_output = container.user_output();
+
+        // Verify we can get the user_output service
+        assert!(Arc::strong_count(&user_output) >= 1);
+    }
+
+    #[test]
+    fn it_should_return_cloned_arc_on_user_output_access() {
+        let container = Container::new();
+        let user_output1 = container.user_output();
+        let user_output2 = container.user_output();
+
+        // Both should point to the same UserOutput instance
+        assert!(Arc::ptr_eq(&user_output1, &user_output2));
+    }
+
+    #[test]
+    fn it_should_be_clonable() {
+        let container1 = Container::new();
+        let container2 = container1.clone();
+
+        let user_output1 = container1.user_output();
+        let user_output2 = container2.user_output();
+
+        // Cloned containers should share the same UserOutput
+        assert!(Arc::ptr_eq(&user_output1, &user_output2));
+    }
+}

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -1,17 +1,20 @@
 //! Bootstrap Module
 //!
 //! This module contains application initialization and bootstrap concerns.
-//! It handles application lifecycle, logging setup, and help display.
+//! It handles application lifecycle, logging setup, help display, and service container.
 //!
 //! ## Modules
 //!
 //! - `app` - Main application bootstrap and entry point logic
+//! - `container` - Application service container for dependency injection
 //! - `help` - Help and usage information display
 //! - `logging` - Logging configuration and initialization
 
 pub mod app;
+pub mod container;
 pub mod help;
 pub mod logging;
 
 // Re-export commonly used types for convenience
+pub use container::Container;
 pub use logging::{LogFormat, LogOutput, LoggingBuilder, LoggingConfig};

--- a/src/presentation/commands/context.rs
+++ b/src/presentation/commands/context.rs
@@ -285,29 +285,6 @@ impl CommandContext {
     pub fn user_output(&self) -> &Arc<std::sync::Mutex<UserOutput>> {
         &self.user_output
     }
-
-    /// Consume the context and return the shared user output
-    ///
-    /// This method is useful when you want to pass ownership of the `Arc<Mutex<UserOutput>>`
-    /// to another component, such as a `ProgressReporter`.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use std::path::PathBuf;
-    /// use std::sync::{Arc, Mutex};
-    /// use torrust_tracker_deployer_lib::presentation::commands::context::CommandContext;
-    /// use torrust_tracker_deployer_lib::presentation::progress::ProgressReporter;
-    /// use torrust_tracker_deployer_lib::presentation::user_output::{UserOutput, VerbosityLevel};
-    ///
-    /// let user_output = Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Normal)));
-    /// let ctx = CommandContext::new(PathBuf::from("."), user_output);
-    /// let progress = ProgressReporter::new(ctx.into_user_output(), 3);
-    /// ```
-    #[must_use]
-    pub fn into_user_output(self) -> Arc<std::sync::Mutex<UserOutput>> {
-        self.user_output
-    }
 }
 
 /// Report an error through user output

--- a/src/presentation/commands/context.rs
+++ b/src/presentation/commands/context.rs
@@ -31,18 +31,21 @@
 //!
 //! ```rust
 //! use std::path::Path;
+//! use std::sync::{Arc, Mutex};
 //! use torrust_tracker_deployer_lib::presentation::commands::context::CommandContext;
+//! use torrust_tracker_deployer_lib::presentation::user_output::{UserOutput, VerbosityLevel};
 //!
 //! fn handle_command(working_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
-//!     let mut ctx = CommandContext::new(working_dir.to_path_buf());
+//!     let output = Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Normal)));
+//!     let mut ctx = CommandContext::new(working_dir.to_path_buf(), output.clone());
 //!     
-//!     ctx.output().progress("Starting operation...");
+//!     output.lock().unwrap().progress("Starting operation...");
 //!     
 //!     // Use repository and clock through context
 //!     let repo = ctx.repository();
 //!     let clock = ctx.clock();
 //!     
-//!     ctx.output().success("Operation completed");
+//!     output.lock().unwrap().success("Operation completed");
 //!     Ok(())
 //! }
 //! ```
@@ -55,7 +58,7 @@ use crate::infrastructure::persistence::repository_factory::RepositoryFactory;
 use crate::presentation::user_output::UserOutput;
 use crate::shared::{Clock, SystemClock};
 
-use super::constants::{DEFAULT_LOCK_TIMEOUT, DEFAULT_VERBOSITY};
+use super::constants::DEFAULT_LOCK_TIMEOUT;
 
 /// Command execution context containing shared dependencies
 ///
@@ -71,10 +74,13 @@ use super::constants::{DEFAULT_LOCK_TIMEOUT, DEFAULT_VERBOSITY};
 ///
 /// ```rust
 /// use std::path::PathBuf;
+/// use std::sync::{Arc, Mutex};
 /// use torrust_tracker_deployer_lib::presentation::commands::context::CommandContext;
+/// use torrust_tracker_deployer_lib::presentation::user_output::{UserOutput, VerbosityLevel};
 ///
 /// let working_dir = PathBuf::from(".");
-/// let mut ctx = CommandContext::new(working_dir);
+/// let user_output = Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Normal)));
+/// let ctx = CommandContext::new(working_dir, user_output.clone());
 ///
 /// // Access repository
 /// let repo = ctx.repository();
@@ -83,13 +89,14 @@ use super::constants::{DEFAULT_LOCK_TIMEOUT, DEFAULT_VERBOSITY};
 /// let clock = ctx.clock();
 ///
 /// // Access user output
-/// ctx.output().progress("Processing...");
-/// ctx.output().success("Complete!");
+/// let mut output = ctx.user_output().lock().unwrap();
+/// output.progress("Processing...");
+/// output.success("Complete!");
 /// ```
 pub struct CommandContext {
     repository: Arc<dyn EnvironmentRepository>,
     clock: Arc<dyn Clock>,
-    output: UserOutput,
+    user_output: Arc<std::sync::Mutex<UserOutput>>,
 }
 
 impl CommandContext {
@@ -99,32 +106,35 @@ impl CommandContext {
     /// and default configuration from constants:
     /// - Repository with default lock timeout
     /// - System clock
-    /// - User output with default verbosity
+    /// - Injected user output service
     ///
     /// # Arguments
     ///
     /// * `working_dir` - Root directory for environment data storage
+    /// * `user_output` - Shared user output service for consistent output formatting
     ///
     /// # Examples
     ///
     /// ```rust
     /// use std::path::PathBuf;
+    /// use std::sync::{Arc, Mutex};
     /// use torrust_tracker_deployer_lib::presentation::commands::context::CommandContext;
+    /// use torrust_tracker_deployer_lib::presentation::user_output::{UserOutput, VerbosityLevel};
     ///
     /// let working_dir = PathBuf::from("./data");
-    /// let ctx = CommandContext::new(working_dir);
+    /// let user_output = Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Normal)));
+    /// let ctx = CommandContext::new(working_dir, user_output);
     /// ```
     #[must_use]
-    pub fn new(working_dir: PathBuf) -> Self {
+    pub fn new(working_dir: PathBuf, user_output: Arc<std::sync::Mutex<UserOutput>>) -> Self {
         let repository_factory = RepositoryFactory::new(DEFAULT_LOCK_TIMEOUT);
         let repository = repository_factory.create(working_dir);
         let clock = Arc::new(SystemClock);
-        let output = UserOutput::new(DEFAULT_VERBOSITY);
 
         Self {
             repository,
             clock,
-            output,
+            user_output,
         }
     }
 
@@ -138,29 +148,36 @@ impl CommandContext {
     ///
     /// * `repository_factory` - Pre-configured repository factory
     /// * `working_dir` - Root directory for environment data storage
+    /// * `user_output` - Shared user output service for consistent output formatting
     ///
     /// # Examples
     ///
     /// ```rust
     /// use std::path::PathBuf;
     /// use std::time::Duration;
+    /// use std::sync::{Arc, Mutex};
     /// use torrust_tracker_deployer_lib::presentation::commands::context::CommandContext;
     /// use torrust_tracker_deployer_lib::infrastructure::persistence::repository_factory::RepositoryFactory;
+    /// use torrust_tracker_deployer_lib::presentation::user_output::{UserOutput, VerbosityLevel};
     ///
     /// let factory = RepositoryFactory::new(Duration::from_secs(30));
     /// let working_dir = PathBuf::from("./data");
-    /// let ctx = CommandContext::new_with_factory(&factory, working_dir);
+    /// let user_output = Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Normal)));
+    /// let ctx = CommandContext::new_with_factory(&factory, working_dir, user_output);
     /// ```
     #[must_use]
-    pub fn new_with_factory(repository_factory: &RepositoryFactory, working_dir: PathBuf) -> Self {
+    pub fn new_with_factory(
+        repository_factory: &RepositoryFactory,
+        working_dir: PathBuf,
+        user_output: Arc<std::sync::Mutex<UserOutput>>,
+    ) -> Self {
         let repository = repository_factory.create(working_dir);
         let clock = Arc::new(SystemClock);
-        let output = UserOutput::new(DEFAULT_VERBOSITY);
 
         Self {
             repository,
             clock,
-            output,
+            user_output,
         }
     }
 
@@ -173,12 +190,12 @@ impl CommandContext {
     ///
     /// * `repository` - Repository implementation (can be a mock)
     /// * `clock` - Clock implementation (can be a mock)
-    /// * `output` - User output instance (can use custom writers)
+    /// * `user_output` - Shared user output service for consistent output formatting
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use std::sync::Arc;
+    /// use std::sync::{Arc, Mutex};
     /// use std::path::PathBuf;
     /// use torrust_tracker_deployer_lib::presentation::commands::context::CommandContext;
     /// use torrust_tracker_deployer_lib::presentation::user_output::{UserOutput, VerbosityLevel};
@@ -190,20 +207,20 @@ impl CommandContext {
     /// let factory = RepositoryFactory::new(Duration::from_secs(5));
     /// let repository = factory.create(PathBuf::from("/tmp/test"));
     /// let clock: Arc<dyn Clock> = Arc::new(SystemClock);
-    /// let output = UserOutput::new(VerbosityLevel::Quiet);
+    /// let user_output = Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Quiet)));
     ///
-    /// let ctx = CommandContext::new_for_testing(repository, clock, output);
+    /// let ctx = CommandContext::new_for_testing(repository, clock, user_output);
     /// ```
     #[must_use]
     pub fn new_for_testing(
         repository: Arc<dyn EnvironmentRepository>,
         clock: Arc<dyn Clock>,
-        output: UserOutput,
+        user_output: Arc<std::sync::Mutex<UserOutput>>,
     ) -> Self {
         Self {
             repository,
             clock,
-            output,
+            user_output,
         }
     }
 
@@ -213,9 +230,12 @@ impl CommandContext {
     ///
     /// ```rust
     /// use std::path::PathBuf;
+    /// use std::sync::{Arc, Mutex};
     /// use torrust_tracker_deployer_lib::presentation::commands::context::CommandContext;
+    /// use torrust_tracker_deployer_lib::presentation::user_output::{UserOutput, VerbosityLevel};
     ///
-    /// let ctx = CommandContext::new(PathBuf::from("."));
+    /// let output = Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Normal)));
+    /// let ctx = CommandContext::new(PathBuf::from("."), output);
     /// let repo = ctx.repository();
     /// ```
     #[must_use]
@@ -229,9 +249,12 @@ impl CommandContext {
     ///
     /// ```rust
     /// use std::path::PathBuf;
+    /// use std::sync::{Arc, Mutex};
     /// use torrust_tracker_deployer_lib::presentation::commands::context::CommandContext;
+    /// use torrust_tracker_deployer_lib::presentation::user_output::{UserOutput, VerbosityLevel};
     ///
-    /// let ctx = CommandContext::new(PathBuf::from("."));
+    /// let output = Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Normal)));
+    /// let ctx = CommandContext::new(PathBuf::from("."), output);
     /// let clock = ctx.clock();
     /// ```
     #[must_use]
@@ -239,40 +262,51 @@ impl CommandContext {
         &self.clock
     }
 
-    /// Get mutable reference to user output
+    /// Get reference to the shared user output
+    ///
+    /// Returns the Arc-wrapped Mutex-protected `UserOutput` instance, allowing
+    /// multiple components to share access to the same output sink.
     ///
     /// # Examples
     ///
     /// ```rust
     /// use std::path::PathBuf;
+    /// use std::sync::{Arc, Mutex};
     /// use torrust_tracker_deployer_lib::presentation::commands::context::CommandContext;
+    /// use torrust_tracker_deployer_lib::presentation::user_output::{UserOutput, VerbosityLevel};
     ///
-    /// let mut ctx = CommandContext::new(PathBuf::from("."));
-    /// ctx.output().progress("Working...");
-    /// ctx.output().success("Done!");
+    /// let user_output = Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Normal)));
+    /// let ctx = CommandContext::new(PathBuf::from("."), user_output);
+    /// let output_ref = ctx.user_output();
+    /// output_ref.lock().unwrap().progress("Working...");
+    /// output_ref.lock().unwrap().success("Done!");
     /// ```
-    pub fn output(&mut self) -> &mut UserOutput {
-        &mut self.output
+    #[must_use]
+    pub fn user_output(&self) -> &Arc<std::sync::Mutex<UserOutput>> {
+        &self.user_output
     }
 
-    /// Consume the context and return the user output
+    /// Consume the context and return the shared user output
     ///
-    /// This method is useful when you want to pass ownership of the output
+    /// This method is useful when you want to pass ownership of the `Arc<Mutex<UserOutput>>`
     /// to another component, such as a `ProgressReporter`.
     ///
     /// # Examples
     ///
     /// ```rust
     /// use std::path::PathBuf;
+    /// use std::sync::{Arc, Mutex};
     /// use torrust_tracker_deployer_lib::presentation::commands::context::CommandContext;
     /// use torrust_tracker_deployer_lib::presentation::progress::ProgressReporter;
+    /// use torrust_tracker_deployer_lib::presentation::user_output::{UserOutput, VerbosityLevel};
     ///
-    /// let ctx = CommandContext::new(PathBuf::from("."));
-    /// let progress = ProgressReporter::new(ctx.into_output(), 3);
+    /// let user_output = Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Normal)));
+    /// let ctx = CommandContext::new(PathBuf::from("."), user_output);
+    /// let progress = ProgressReporter::new(ctx.into_user_output(), 3);
     /// ```
     #[must_use]
-    pub fn into_output(self) -> UserOutput {
-        self.output
+    pub fn into_user_output(self) -> Arc<std::sync::Mutex<UserOutput>> {
+        self.user_output
     }
 }
 
@@ -289,15 +323,25 @@ impl CommandContext {
 /// # Examples
 ///
 /// ```rust
+/// use std::sync::{Arc, Mutex};
 /// use torrust_tracker_deployer_lib::presentation::commands::context::report_error;
 /// use torrust_tracker_deployer_lib::presentation::user_output::{UserOutput, VerbosityLevel};
 ///
-/// let mut output = UserOutput::new(VerbosityLevel::Normal);
+/// let output = Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Normal)));
 /// let error = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
-/// report_error(&mut output, &error);
+/// report_error(&output, &error);
 /// ```
-pub fn report_error(output: &mut UserOutput, error: &dyn std::error::Error) {
-    output.error(&error.to_string());
+pub fn report_error(
+    user_output: &Arc<std::sync::Mutex<UserOutput>>,
+    error: &dyn std::error::Error,
+) {
+    // Try to acquire the lock and report the error through the configured
+    // `UserOutput`. If the lock is poisoned, fallback to writing to stderr so
+    // the user still sees the message instead of panicking.
+    match user_output.lock() {
+        Ok(mut output) => output.error(&error.to_string()),
+        Err(_) => eprintln!("Error: {error}"),
+    }
 }
 
 #[cfg(test)]
@@ -306,12 +350,22 @@ mod tests {
     use std::io::Cursor;
     use tempfile::TempDir;
 
+    use crate::presentation::user_output::VerbosityLevel;
+
+    /// Test helper to create a test user output
+    fn create_test_user_output() -> Arc<std::sync::Mutex<UserOutput>> {
+        Arc::new(std::sync::Mutex::new(UserOutput::new(
+            VerbosityLevel::Normal,
+        )))
+    }
+
     #[test]
     fn it_should_create_context_with_production_dependencies() {
         let temp_dir = TempDir::new().unwrap();
         let working_dir = temp_dir.path().to_path_buf();
+        let user_output = create_test_user_output();
 
-        let ctx = CommandContext::new(working_dir);
+        let ctx = CommandContext::new(working_dir, user_output);
 
         // Verify dependencies are present and accessible (we can call methods on them)
         let _ = ctx.repository();
@@ -322,8 +376,9 @@ mod tests {
     fn it_should_provide_access_to_repository() {
         let temp_dir = TempDir::new().unwrap();
         let working_dir = temp_dir.path().to_path_buf();
+        let user_output = create_test_user_output();
 
-        let ctx = CommandContext::new(working_dir);
+        let ctx = CommandContext::new(working_dir, user_output);
 
         // Should be able to access repository
         let _repo = ctx.repository();
@@ -333,32 +388,36 @@ mod tests {
     fn it_should_provide_access_to_clock() {
         let temp_dir = TempDir::new().unwrap();
         let working_dir = temp_dir.path().to_path_buf();
+        let user_output = create_test_user_output();
 
-        let ctx = CommandContext::new(working_dir);
+        let ctx = CommandContext::new(working_dir, user_output);
 
         // Should be able to access clock
         let _clock = ctx.clock();
     }
 
     #[test]
-    fn it_should_provide_mutable_access_to_output() {
+    fn it_should_provide_access_to_user_output() {
         let temp_dir = TempDir::new().unwrap();
         let working_dir = temp_dir.path().to_path_buf();
+        let user_output = create_test_user_output();
 
-        let mut ctx = CommandContext::new(working_dir);
+        let ctx = CommandContext::new(working_dir, user_output);
 
-        // Should be able to use output methods
-        ctx.output().progress("Test progress");
-        ctx.output().success("Test success");
+        // Should be able to use output methods through Arc<Mutex<>>
+        let output_ref = ctx.user_output();
+        output_ref.lock().unwrap().progress("Test progress");
+        output_ref.lock().unwrap().success("Test success");
     }
 
     #[test]
     fn it_should_create_context_with_factory() {
         let temp_dir = TempDir::new().unwrap();
         let working_dir = temp_dir.path().to_path_buf();
+        let user_output = create_test_user_output();
 
         let repository_factory = RepositoryFactory::new(DEFAULT_LOCK_TIMEOUT);
-        let ctx = CommandContext::new_with_factory(&repository_factory, working_dir);
+        let ctx = CommandContext::new_with_factory(&repository_factory, working_dir, user_output);
 
         // Verify we can access all dependencies
         let _repo = ctx.repository();
@@ -374,10 +433,12 @@ mod tests {
         let repository_factory = RepositoryFactory::new(DEFAULT_LOCK_TIMEOUT);
         let repository = repository_factory.create(working_dir);
         let clock: Arc<dyn Clock> = Arc::new(SystemClock);
-        let output = UserOutput::new(DEFAULT_VERBOSITY);
+        let user_output = Arc::new(std::sync::Mutex::new(UserOutput::new(
+            VerbosityLevel::Normal,
+        )));
 
         // Create context with test dependencies
-        let ctx = CommandContext::new_for_testing(repository, clock, output);
+        let ctx = CommandContext::new_for_testing(repository, clock, user_output);
 
         // Verify we can access all dependencies
         let _repo = ctx.repository();
@@ -388,13 +449,15 @@ mod tests {
     fn it_should_allow_accessing_output_multiple_times() {
         let temp_dir = TempDir::new().unwrap();
         let working_dir = temp_dir.path().to_path_buf();
+        let user_output = create_test_user_output();
 
-        let mut ctx = CommandContext::new(working_dir);
+        let ctx = CommandContext::new(working_dir, user_output);
 
-        // Should be able to call output() multiple times
-        ctx.output().progress("First message");
-        ctx.output().success("Second message");
-        ctx.output().error("Third message");
+        // Should be able to call user_output() multiple times
+        let output_ref = ctx.user_output();
+        output_ref.lock().unwrap().progress("First message");
+        output_ref.lock().unwrap().success("Second message");
+        output_ref.lock().unwrap().error("Third message");
     }
 
     #[test]
@@ -404,11 +467,12 @@ mod tests {
         let stderr_writer = Box::new(Cursor::new(stderr_buf));
         let stdout_writer = Box::new(Cursor::new(Vec::new()));
 
-        let mut output = UserOutput::with_writers(DEFAULT_VERBOSITY, stdout_writer, stderr_writer);
+        let output = UserOutput::with_writers(VerbosityLevel::Normal, stdout_writer, stderr_writer);
 
-        // Create an error and report it
+        // Wrap output in Arc<Mutex<>> and report the error through the new API
+        let shared_output = Arc::new(std::sync::Mutex::new(output));
         let error = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
-        report_error(&mut output, &error);
+        report_error(&shared_output, &error);
 
         // Note: In a real test, we'd verify the output was written,
         // but that requires extracting the buffer from output which isn't directly possible
@@ -419,9 +483,10 @@ mod tests {
     fn it_should_use_default_constants() {
         let temp_dir = TempDir::new().unwrap();
         let working_dir = temp_dir.path().to_path_buf();
+        let user_output = create_test_user_output();
 
-        // Creating context should use DEFAULT_LOCK_TIMEOUT and DEFAULT_VERBOSITY
-        let _ctx = CommandContext::new(working_dir);
+        // Creating context should use DEFAULT_LOCK_TIMEOUT
+        let _ctx = CommandContext::new(working_dir, user_output);
 
         // This test verifies that the code compiles with the constants
         // The actual values are tested in the constants module

--- a/src/presentation/commands/context.rs
+++ b/src/presentation/commands/context.rs
@@ -301,11 +301,20 @@ mod tests {
         )))
     }
 
-    #[test]
-    fn it_should_create_context_with_production_dependencies() {
+    /// Test helper to create a test context with temporary directory
+    ///
+    /// Returns a tuple of (`TempDir`, `PathBuf`, `Arc<Mutex<UserOutput>>`)
+    /// The `TempDir` must be kept alive for the duration of the test.
+    fn create_test_setup() -> (TempDir, PathBuf, Arc<std::sync::Mutex<UserOutput>>) {
         let temp_dir = TempDir::new().unwrap();
         let working_dir = temp_dir.path().to_path_buf();
         let user_output = create_test_user_output();
+        (temp_dir, working_dir, user_output)
+    }
+
+    #[test]
+    fn it_should_create_context_with_production_dependencies() {
+        let (_temp_dir, working_dir, user_output) = create_test_setup();
 
         let ctx = CommandContext::new(working_dir, user_output);
 
@@ -316,9 +325,7 @@ mod tests {
 
     #[test]
     fn it_should_provide_access_to_repository() {
-        let temp_dir = TempDir::new().unwrap();
-        let working_dir = temp_dir.path().to_path_buf();
-        let user_output = create_test_user_output();
+        let (_temp_dir, working_dir, user_output) = create_test_setup();
 
         let ctx = CommandContext::new(working_dir, user_output);
 
@@ -328,9 +335,7 @@ mod tests {
 
     #[test]
     fn it_should_provide_access_to_clock() {
-        let temp_dir = TempDir::new().unwrap();
-        let working_dir = temp_dir.path().to_path_buf();
-        let user_output = create_test_user_output();
+        let (_temp_dir, working_dir, user_output) = create_test_setup();
 
         let ctx = CommandContext::new(working_dir, user_output);
 
@@ -340,9 +345,7 @@ mod tests {
 
     #[test]
     fn it_should_provide_access_to_user_output() {
-        let temp_dir = TempDir::new().unwrap();
-        let working_dir = temp_dir.path().to_path_buf();
-        let user_output = create_test_user_output();
+        let (_temp_dir, working_dir, user_output) = create_test_setup();
 
         let ctx = CommandContext::new(working_dir, user_output);
 
@@ -354,9 +357,7 @@ mod tests {
 
     #[test]
     fn it_should_create_context_with_factory() {
-        let temp_dir = TempDir::new().unwrap();
-        let working_dir = temp_dir.path().to_path_buf();
-        let user_output = create_test_user_output();
+        let (_temp_dir, working_dir, user_output) = create_test_setup();
 
         let repository_factory = RepositoryFactory::new(DEFAULT_LOCK_TIMEOUT);
         let ctx = CommandContext::new_with_factory(&repository_factory, working_dir, user_output);
@@ -389,9 +390,7 @@ mod tests {
 
     #[test]
     fn it_should_allow_accessing_output_multiple_times() {
-        let temp_dir = TempDir::new().unwrap();
-        let working_dir = temp_dir.path().to_path_buf();
-        let user_output = create_test_user_output();
+        let (_temp_dir, working_dir, user_output) = create_test_setup();
 
         let ctx = CommandContext::new(working_dir, user_output);
 
@@ -404,9 +403,7 @@ mod tests {
 
     #[test]
     fn it_should_use_default_constants() {
-        let temp_dir = TempDir::new().unwrap();
-        let working_dir = temp_dir.path().to_path_buf();
-        let user_output = create_test_user_output();
+        let (_temp_dir, working_dir, user_output) = create_test_setup();
 
         // Creating context should use DEFAULT_LOCK_TIMEOUT
         let _ctx = CommandContext::new(working_dir, user_output);

--- a/src/presentation/commands/create/errors.rs
+++ b/src/presentation/commands/create/errors.rs
@@ -130,6 +130,16 @@ Tip: This is a critical bug - please report it with full logs using --log-output
     },
 }
 
+// ============================================================================
+// ERROR CONVERSIONS
+// ============================================================================
+
+impl From<ProgressReporterError> for CreateSubcommandError {
+    fn from(source: ProgressReporterError) -> Self {
+        Self::ProgressReportingFailed { source }
+    }
+}
+
 impl CreateSubcommandError {
     /// Provides detailed troubleshooting guidance for this error
     ///

--- a/src/presentation/commands/create/errors.rs
+++ b/src/presentation/commands/create/errors.rs
@@ -106,6 +106,14 @@ Tip: Check that you have write permissions in the target directory"
         #[source]
         source: crate::application::command_handlers::create::config::CreateConfigError,
     },
+
+    // ===== User Output Lock Errors =====
+    /// User output lock acquisition failed
+    ///
+    /// Failed to acquire the mutex lock for user output. This indicates a panic
+    /// occurred in another thread while holding the lock.
+    #[error("Failed to acquire user output lock - a panic occurred in another thread")]
+    UserOutputLockFailed,
 }
 
 impl CreateSubcommandError {
@@ -187,6 +195,27 @@ For more information, see the configuration documentation."
                 source.help()
             }
             Self::CommandFailed { source } => source.help(),
+            Self::UserOutputLockFailed => {
+                "User Output Lock Failed - Troubleshooting:
+
+This error indicates that a panic occurred in another thread while it was using
+the user output system, leaving the mutex in a \"poisoned\" state.
+
+1. Check for any error messages that appeared before this one
+   - The original panic message should appear earlier in the output
+   - This will indicate what caused the initial failure
+
+2. This is typically caused by:
+   - A bug in the application code that caused a panic
+   - An unhandled error condition that triggered a panic
+   - Resource exhaustion (memory, file handles, etc.)
+
+3. If you can reproduce this issue:
+   - Run with --verbose to see more detailed logging
+   - Report the issue with the full error output and steps to reproduce
+
+This is a serious application error that indicates a bug. Please report it to the developers."
+            }
         }
     }
 }

--- a/src/presentation/commands/create/handler.rs
+++ b/src/presentation/commands/create/handler.rs
@@ -4,8 +4,10 @@
 //! routing between different subcommands (environment creation or template generation).
 
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 use crate::presentation::cli::commands::CreateAction;
+use crate::presentation::user_output::UserOutput;
 
 use super::errors::CreateSubcommandError;
 use super::subcommands;
@@ -18,6 +20,7 @@ use super::subcommands;
 ///
 /// * `action` - The create action to perform (environment creation or template generation)
 /// * `working_dir` - Root directory for environment data storage
+/// * `user_output` - Shared user output service for consistent output formatting
 ///
 /// # Returns
 ///
@@ -30,14 +33,15 @@ use super::subcommands;
 pub fn handle_create_command(
     action: CreateAction,
     working_dir: &Path,
+    user_output: &Arc<Mutex<UserOutput>>,
 ) -> Result<(), CreateSubcommandError> {
     match action {
         CreateAction::Environment { env_file } => {
-            subcommands::handle_environment_creation(&env_file, working_dir)
+            subcommands::handle_environment_creation(&env_file, working_dir, user_output)
         }
         CreateAction::Template { output_path } => {
             let template_path = output_path.unwrap_or_else(CreateAction::default_template_path);
-            subcommands::handle_template_generation(&template_path)
+            subcommands::handle_template_generation(&template_path, user_output)
         }
     }
 }

--- a/src/presentation/commands/create/mod.rs
+++ b/src/presentation/commands/create/mod.rs
@@ -22,14 +22,17 @@
 //!
 //! ```rust,no_run
 //! use std::path::{Path, PathBuf};
+//! use std::sync::{Arc, Mutex};
 //! use torrust_tracker_deployer_lib::presentation::cli::commands::CreateAction;
 //! use torrust_tracker_deployer_lib::presentation::commands::create;
+//! use torrust_tracker_deployer_lib::presentation::user_output::{UserOutput, VerbosityLevel};
 //!
 //! let action = CreateAction::Environment {
 //!     env_file: PathBuf::from("config/environment.json")
 //! };
+//! let output = Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Normal)));
 //!
-//! if let Err(e) = create::handle_create_command(action, Path::new(".")) {
+//! if let Err(e) = create::handle_create_command(action, Path::new("."), &output) {
 //!     eprintln!("Create failed: {e}");
 //!     eprintln!("\n{}", e.help());
 //! }

--- a/src/presentation/commands/create/subcommands/environment.rs
+++ b/src/presentation/commands/create/subcommands/environment.rs
@@ -4,6 +4,7 @@
 //! deployment environments from configuration files.
 
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 use crate::application::command_handlers::create::config::EnvironmentCreationConfig;
 use crate::domain::Environment;
@@ -31,6 +32,7 @@ use super::super::errors::CreateSubcommandError;
 ///
 /// * `env_file` - Path to the environment configuration file (JSON format)
 /// * `working_dir` - Root directory for environment data storage
+/// * `user_output` - Shared user output service for consistent output formatting
 ///
 /// # Returns
 ///
@@ -47,12 +49,13 @@ use super::super::errors::CreateSubcommandError;
 pub fn handle_environment_creation(
     env_file: &Path,
     working_dir: &Path,
+    user_output: &Arc<Mutex<UserOutput>>,
 ) -> Result<(), CreateSubcommandError> {
     let factory = CommandHandlerFactory::new();
-    let ctx = factory.create_context(working_dir.to_path_buf());
+    let ctx = factory.create_context(working_dir.to_path_buf(), user_output.clone());
 
     // Create progress reporter for 3 main steps
-    let mut progress = ProgressReporter::new(ctx.into_output(), 3);
+    let mut progress = ProgressReporter::new(ctx.into_user_output(), 3);
 
     // Step 1: Load configuration
     progress.start_step("Loading configuration");
@@ -64,7 +67,7 @@ pub fn handle_environment_creation(
 
     // Step 2: Initialize dependencies
     progress.start_step("Initializing dependencies");
-    let ctx = factory.create_context(working_dir.to_path_buf());
+    let ctx = factory.create_context(working_dir.to_path_buf(), user_output.clone());
     let command_handler = factory.create_create_handler(&ctx);
     progress.complete_step(None);
 
@@ -111,17 +114,21 @@ pub fn handle_environment_creation(
 /// - JSON parsing fails
 /// - Domain validation fails
 fn load_configuration(
-    output: &mut UserOutput,
+    user_output: &Arc<Mutex<UserOutput>>,
     env_file: &Path,
 ) -> Result<EnvironmentCreationConfig, CreateSubcommandError> {
-    output.progress(&format!(
-        "Loading configuration from '{}'...",
-        env_file.display()
-    ));
+    user_output
+        .lock()
+        .expect("UserOutput mutex poisoned")
+        .progress(&format!(
+            "Loading configuration from '{}'...",
+            env_file.display()
+        ));
 
     let loader = ConfigLoader;
+
     loader.load_from_file(env_file).inspect_err(|err| {
-        report_error(output, err);
+        report_error(user_output, err);
     })
 }
 
@@ -145,21 +152,27 @@ fn load_configuration(
 ///
 /// Returns an error if command execution fails (e.g., environment already exists).
 fn execute_create_command(
-    output: &mut UserOutput,
+    user_output: &Arc<Mutex<UserOutput>>,
     command_handler: &crate::application::command_handlers::CreateCommandHandler,
     config: EnvironmentCreationConfig,
 ) -> Result<Environment, CreateSubcommandError> {
-    output.progress(&format!(
-        "Creating environment '{}'...",
-        config.environment.name
-    ));
+    user_output
+        .lock()
+        .expect("UserOutput mutex poisoned")
+        .progress(&format!(
+            "Creating environment '{}'...",
+            config.environment.name
+        ));
 
-    output.progress("Validating configuration and creating environment...");
+    user_output
+        .lock()
+        .expect("UserOutput mutex poisoned")
+        .progress("Validating configuration and creating environment...");
 
     #[allow(clippy::manual_inspect)]
     command_handler.execute(config).map_err(|source| {
         let error = CreateSubcommandError::CommandFailed { source };
-        report_error(output, &error);
+        report_error(user_output, &error);
         error
     })
 }
@@ -174,9 +187,11 @@ fn execute_create_command(
 ///
 /// # Arguments
 ///
-/// * `output` - User output for result messages
+/// * `user_output` - Shared user output for result messages
 /// * `environment` - The successfully created environment
-fn display_creation_results(output: &mut UserOutput, environment: &Environment) {
+fn display_creation_results(user_output: &Arc<Mutex<UserOutput>>, environment: &Environment) {
+    let mut output = user_output.lock().expect("UserOutput mutex poisoned");
+
     output.success(&format!(
         "Environment '{}' created successfully",
         environment.name().as_str()
@@ -186,10 +201,12 @@ fn display_creation_results(output: &mut UserOutput, environment: &Environment) 
         "Instance name: {}",
         environment.instance_name().as_str()
     ));
+
     output.result(&format!(
         "Data directory: {}",
         environment.data_dir().display()
     ));
+
     output.result(&format!(
         "Build directory: {}",
         environment.build_dir().display()
@@ -199,8 +216,14 @@ fn display_creation_results(output: &mut UserOutput, environment: &Environment) 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::presentation::user_output::VerbosityLevel;
     use std::fs;
     use tempfile::TempDir;
+
+    /// Test helper to create a test user output
+    fn create_test_user_output() -> Arc<Mutex<UserOutput>> {
+        Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Normal)))
+    }
 
     #[test]
     fn it_should_create_environment_from_valid_config() {
@@ -227,7 +250,8 @@ mod tests {
         fs::write(&config_path, config_json).unwrap();
 
         let working_dir = temp_dir.path();
-        let result = handle_environment_creation(&config_path, working_dir);
+        let user_output = create_test_user_output();
+        let result = handle_environment_creation(&config_path, working_dir, &user_output);
 
         assert!(
             result.is_ok(),
@@ -250,8 +274,9 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let config_path = temp_dir.path().join("nonexistent.json");
         let working_dir = temp_dir.path();
+        let user_output = create_test_user_output();
 
-        let result = handle_environment_creation(&config_path, working_dir);
+        let result = handle_environment_creation(&config_path, working_dir, &user_output);
 
         assert!(result.is_err());
         match result.unwrap_err() {
@@ -271,7 +296,8 @@ mod tests {
         fs::write(&config_path, r#"{"invalid json"#).unwrap();
 
         let working_dir = temp_dir.path();
-        let result = handle_environment_creation(&config_path, working_dir);
+        let user_output = create_test_user_output();
+        let result = handle_environment_creation(&config_path, working_dir, &user_output);
 
         assert!(result.is_err());
         match result.unwrap_err() {
@@ -306,13 +332,14 @@ mod tests {
         fs::write(&config_path, config_json).unwrap();
 
         let working_dir = temp_dir.path();
+        let user_output = create_test_user_output();
 
         // Create environment first time
-        let result1 = handle_environment_creation(&config_path, working_dir);
+        let result1 = handle_environment_creation(&config_path, working_dir, &user_output);
         assert!(result1.is_ok(), "First create should succeed");
 
         // Try to create same environment again
-        let result2 = handle_environment_creation(&config_path, working_dir);
+        let result2 = handle_environment_creation(&config_path, working_dir, &user_output);
         assert!(result2.is_err(), "Second create should fail");
 
         match result2.unwrap_err() {
@@ -349,7 +376,8 @@ mod tests {
         );
         fs::write(&config_path, config_json).unwrap();
 
-        let result = handle_environment_creation(&config_path, &custom_working_dir);
+        let user_output = create_test_user_output();
+        let result = handle_environment_creation(&config_path, &custom_working_dir, &user_output);
 
         assert!(result.is_ok(), "Should create in custom working dir");
 
@@ -369,7 +397,6 @@ mod tests {
 
     mod load_configuration_tests {
         use super::*;
-        use crate::presentation::user_output::{UserOutput, VerbosityLevel};
 
         #[test]
         fn it_should_load_valid_configuration() {
@@ -393,8 +420,8 @@ mod tests {
             );
             fs::write(&config_path, config_json).unwrap();
 
-            let mut output = UserOutput::new(VerbosityLevel::Quiet);
-            let result = load_configuration(&mut output, &config_path);
+            let user_output = create_test_user_output();
+            let result = load_configuration(&user_output, &config_path);
 
             assert!(result.is_ok(), "Should load valid configuration");
             let config = result.unwrap();
@@ -406,8 +433,8 @@ mod tests {
             let temp_dir = TempDir::new().unwrap();
             let config_path = temp_dir.path().join("missing.json");
 
-            let mut output = UserOutput::new(VerbosityLevel::Quiet);
-            let result = load_configuration(&mut output, &config_path);
+            let user_output = create_test_user_output();
+            let result = load_configuration(&user_output, &config_path);
 
             assert!(result.is_err());
             match result.unwrap_err() {
@@ -424,8 +451,8 @@ mod tests {
             let config_path = temp_dir.path().join("invalid.json");
             fs::write(&config_path, r#"{"broken json"#).unwrap();
 
-            let mut output = UserOutput::new(VerbosityLevel::Quiet);
-            let result = load_configuration(&mut output, &config_path);
+            let user_output = create_test_user_output();
+            let result = load_configuration(&user_output, &config_path);
 
             assert!(result.is_err());
             match result.unwrap_err() {
@@ -439,7 +466,6 @@ mod tests {
 
     mod execute_create_command_tests {
         use super::*;
-        use crate::presentation::user_output::{UserOutput, VerbosityLevel};
 
         #[test]
         fn it_should_execute_command_successfully() {
@@ -463,14 +489,14 @@ mod tests {
             );
             fs::write(&config_path, config_json).unwrap();
 
-            let mut output = UserOutput::new(VerbosityLevel::Quiet);
+            let user_output = create_test_user_output();
             let loader = ConfigLoader;
             let config = loader.load_from_file(&config_path).unwrap();
 
             let factory = CommandHandlerFactory::new();
-            let ctx = factory.create_context(temp_dir.path().to_path_buf());
+            let ctx = factory.create_context(temp_dir.path().to_path_buf(), user_output.clone());
             let command_handler = factory.create_create_handler(&ctx);
-            let result = execute_create_command(&mut output, &command_handler, config);
+            let result = execute_create_command(&user_output, &command_handler, config);
 
             assert!(result.is_ok(), "Should execute command successfully");
             let environment = result.unwrap();
@@ -499,21 +525,21 @@ mod tests {
             );
             fs::write(&config_path, config_json).unwrap();
 
-            let mut output = UserOutput::new(VerbosityLevel::Quiet);
+            let user_output = create_test_user_output();
             let loader = ConfigLoader;
             let config = loader.load_from_file(&config_path).unwrap();
 
             let factory = CommandHandlerFactory::new();
-            let ctx = factory.create_context(temp_dir.path().to_path_buf());
+            let ctx = factory.create_context(temp_dir.path().to_path_buf(), user_output.clone());
 
             // Create environment first time
             let command_handler1 = factory.create_create_handler(&ctx);
-            let result1 = execute_create_command(&mut output, &command_handler1, config.clone());
+            let result1 = execute_create_command(&user_output, &command_handler1, config.clone());
             assert!(result1.is_ok(), "First execution should succeed");
 
             // Try to create same environment again
             let command_handler2 = factory.create_create_handler(&ctx);
-            let result2 = execute_create_command(&mut output, &command_handler2, config);
+            let result2 = execute_create_command(&user_output, &command_handler2, config);
             assert!(result2.is_err(), "Second execution should fail");
 
             match result2.unwrap_err() {
@@ -553,14 +579,14 @@ mod tests {
             fs::write(&config_path, config_json).unwrap();
 
             // Create environment
+            let user_output = create_test_user_output();
             let factory = CommandHandlerFactory::new();
-            let ctx = factory.create_context(temp_dir.path().to_path_buf());
+            let ctx = factory.create_context(temp_dir.path().to_path_buf(), user_output.clone());
             let loader = ConfigLoader;
             let config = loader.load_from_file(&config_path).unwrap();
-            let mut quiet_output = UserOutput::new(VerbosityLevel::Quiet);
             let command_handler = factory.create_create_handler(&ctx);
             let environment =
-                execute_create_command(&mut quiet_output, &command_handler, config).unwrap();
+                execute_create_command(&user_output, &command_handler, config).unwrap();
 
             // Test display function with custom output
             let stderr_buf = Vec::new();
@@ -568,11 +594,12 @@ mod tests {
             let stdout_buf = Vec::new();
             let stdout_writer = Box::new(Cursor::new(stdout_buf));
 
-            let mut output =
+            let output =
                 UserOutput::with_writers(VerbosityLevel::Normal, stdout_writer, stderr_writer);
+            let display_output = Arc::new(Mutex::new(output));
 
             // This should not panic and should output messages
-            display_creation_results(&mut output, &environment);
+            display_creation_results(&display_output, &environment);
 
             // Note: We can't easily verify the exact output without refactoring UserOutput
             // to expose the buffers, but the important thing is it doesn't panic

--- a/src/presentation/commands/create/subcommands/environment.rs
+++ b/src/presentation/commands/create/subcommands/environment.rs
@@ -8,7 +8,6 @@ use std::sync::{Arc, Mutex};
 
 use crate::application::command_handlers::create::config::EnvironmentCreationConfig;
 use crate::domain::Environment;
-use crate::presentation::commands::context::report_error;
 use crate::presentation::commands::factory::CommandHandlerFactory;
 use crate::presentation::progress::ProgressReporter;
 use crate::presentation::user_output::UserOutput;
@@ -127,7 +126,10 @@ fn load_configuration(
     let loader = ConfigLoader;
 
     loader.load_from_file(env_file).inspect_err(|err| {
-        report_error(user_output, err);
+        user_output
+            .lock()
+            .expect("UserOutput mutex poisoned")
+            .error(&err.to_string());
     })
 }
 
@@ -171,7 +173,10 @@ fn execute_create_command(
     #[allow(clippy::manual_inspect)]
     command_handler.execute(config).map_err(|source| {
         let error = CreateSubcommandError::CommandFailed { source };
-        report_error(user_output, &error);
+        user_output
+            .lock()
+            .expect("UserOutput mutex poisoned")
+            .error(&error.to_string());
         error
     })
 }

--- a/src/presentation/commands/create/subcommands/environment.rs
+++ b/src/presentation/commands/create/subcommands/environment.rs
@@ -55,7 +55,7 @@ pub fn handle_environment_creation(
     let ctx = factory.create_context(working_dir.to_path_buf(), user_output.clone());
 
     // Create progress reporter for 3 main steps
-    let mut progress = ProgressReporter::new(ctx.into_user_output(), 3);
+    let mut progress = ProgressReporter::new(user_output.clone(), 3);
 
     // Step 1: Load configuration
     progress.start_step("Loading configuration");
@@ -67,7 +67,6 @@ pub fn handle_environment_creation(
 
     // Step 2: Initialize dependencies
     progress.start_step("Initializing dependencies");
-    let ctx = factory.create_context(working_dir.to_path_buf(), user_output.clone());
     let command_handler = factory.create_create_handler(&ctx);
     progress.complete_step(None);
 

--- a/src/presentation/commands/create/subcommands/environment.rs
+++ b/src/presentation/commands/create/subcommands/environment.rs
@@ -57,45 +57,31 @@ pub fn handle_environment_creation(
     let mut progress = ProgressReporter::new(user_output.clone(), 3);
 
     // Step 1: Load configuration
-    progress
-        .start_step("Loading configuration")
-        .map_err(|e| CreateSubcommandError::ProgressReportingFailed { source: e })?;
+    progress.start_step("Loading configuration")?;
     let config = load_configuration(progress.output(), env_file)?;
-    progress
-        .complete_step(Some(&format!(
-            "Configuration loaded: {}",
-            config.environment.name
-        )))
-        .map_err(|e| CreateSubcommandError::ProgressReportingFailed { source: e })?;
+    progress.complete_step(Some(&format!(
+        "Configuration loaded: {}",
+        config.environment.name
+    )))?;
 
     // Step 2: Initialize dependencies
-    progress
-        .start_step("Initializing dependencies")
-        .map_err(|e| CreateSubcommandError::ProgressReportingFailed { source: e })?;
+    progress.start_step("Initializing dependencies")?;
     let command_handler = factory.create_create_handler(&ctx);
-    progress
-        .complete_step(None)
-        .map_err(|e| CreateSubcommandError::ProgressReportingFailed { source: e })?;
+    progress.complete_step(None)?;
 
     // Step 3: Execute create command (provision infrastructure)
-    progress
-        .start_step("Creating environment")
-        .map_err(|e| CreateSubcommandError::ProgressReportingFailed { source: e })?;
+    progress.start_step("Creating environment")?;
     let environment = execute_create_command(progress.output(), &command_handler, config)?;
-    progress
-        .complete_step(Some(&format!(
-            "Instance created: {}",
-            environment.instance_name().as_str()
-        )))
-        .map_err(|e| CreateSubcommandError::ProgressReportingFailed { source: e })?;
+    progress.complete_step(Some(&format!(
+        "Instance created: {}",
+        environment.instance_name().as_str()
+    )))?;
 
     // Complete with summary
-    progress
-        .complete(&format!(
-            "Environment '{}' created successfully",
-            environment.name().as_str()
-        ))
-        .map_err(|e| CreateSubcommandError::ProgressReportingFailed { source: e })?;
+    progress.complete(&format!(
+        "Environment '{}' created successfully",
+        environment.name().as_str()
+    ))?;
 
     // Display final results
     display_creation_results(progress.output(), &environment);
@@ -131,9 +117,7 @@ fn load_configuration(
 ) -> Result<EnvironmentCreationConfig, CreateSubcommandError> {
     user_output
         .lock()
-        .map_err(|_| CreateSubcommandError::ProgressReportingFailed {
-            source: crate::presentation::progress::ProgressReporterError::UserOutputMutexPoisoned,
-        })?
+        .map_err(|_| crate::presentation::progress::ProgressReporterError::UserOutputMutexPoisoned)?
         .progress(&format!(
             "Loading configuration from '{}'...",
             env_file.display()
@@ -175,9 +159,7 @@ fn execute_create_command(
 ) -> Result<Environment, CreateSubcommandError> {
     user_output
         .lock()
-        .map_err(|_| CreateSubcommandError::ProgressReportingFailed {
-            source: crate::presentation::progress::ProgressReporterError::UserOutputMutexPoisoned,
-        })?
+        .map_err(|_| crate::presentation::progress::ProgressReporterError::UserOutputMutexPoisoned)?
         .progress(&format!(
             "Creating environment '{}'...",
             config.environment.name
@@ -185,9 +167,7 @@ fn execute_create_command(
 
     user_output
         .lock()
-        .map_err(|_| CreateSubcommandError::ProgressReportingFailed {
-            source: crate::presentation::progress::ProgressReporterError::UserOutputMutexPoisoned,
-        })?
+        .map_err(|_| crate::presentation::progress::ProgressReporterError::UserOutputMutexPoisoned)?
         .progress("Validating configuration and creating environment...");
 
     #[allow(clippy::manual_inspect)]

--- a/src/presentation/commands/create/subcommands/template.rs
+++ b/src/presentation/commands/create/subcommands/template.rs
@@ -4,9 +4,9 @@
 //! configuration file templates with placeholder values.
 
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 use crate::application::command_handlers::create::config::EnvironmentCreationConfig;
-use crate::presentation::commands::constants::DEFAULT_VERBOSITY;
 use crate::presentation::user_output::UserOutput;
 
 use super::super::errors::CreateSubcommandError;
@@ -19,6 +19,7 @@ use super::super::errors::CreateSubcommandError;
 /// # Arguments
 ///
 /// * `output_path` - Path where the template file should be created
+/// * `user_output` - Shared user output service for consistent output formatting
 ///
 /// # Returns
 ///
@@ -33,9 +34,14 @@ use super::super::errors::CreateSubcommandError;
 /// Panics if the tokio runtime cannot be created. This is a critical system
 /// failure that prevents any async operations from running.
 #[allow(clippy::result_large_err)] // Error contains detailed context for user guidance
-pub fn handle_template_generation(output_path: &Path) -> Result<(), CreateSubcommandError> {
-    // Create user output for progress messages
-    let mut output = UserOutput::new(DEFAULT_VERBOSITY);
+pub fn handle_template_generation(
+    output_path: &Path,
+    user_output: &Arc<Mutex<UserOutput>>,
+) -> Result<(), CreateSubcommandError> {
+    // Lock user output for progress messages
+    let mut output = user_output
+        .lock()
+        .map_err(|_| CreateSubcommandError::UserOutputLockFailed)?;
 
     output.progress("Generating configuration template...");
 

--- a/src/presentation/commands/create/tests/integration.rs
+++ b/src/presentation/commands/create/tests/integration.rs
@@ -3,12 +3,20 @@
 //! This module tests the complete create command workflow including
 //! configuration loading, validation, and command execution.
 
+use std::sync::{Arc, Mutex};
+
 use crate::presentation::cli::CreateAction;
 use crate::presentation::commands::create;
 use crate::presentation::commands::tests::{
     create_config_with_invalid_name, create_config_with_missing_keys, create_invalid_json_config,
     create_valid_config, TestContext,
 };
+use crate::presentation::user_output::{UserOutput, VerbosityLevel};
+
+/// Helper to create test `UserOutput`
+fn create_test_user_output() -> Arc<Mutex<UserOutput>> {
+    Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Normal)))
+}
 
 /// Helper function to call the environment creation handler
 fn handle_environment_creation(
@@ -18,7 +26,8 @@ fn handle_environment_creation(
     let action = CreateAction::Environment {
         env_file: config_path.to_path_buf(),
     };
-    create::handle_create_command(action, working_dir)
+    let user_output = create_test_user_output();
+    create::handle_create_command(action, working_dir, &user_output)
 }
 
 #[test]

--- a/src/presentation/commands/create/tests/template.rs
+++ b/src/presentation/commands/create/tests/template.rs
@@ -1,8 +1,16 @@
 //! Integration Tests for Template Generation
 
+use std::sync::{Arc, Mutex};
+
 use crate::presentation::cli::CreateAction;
 use crate::presentation::commands::create;
 use crate::presentation::commands::tests::TestContext;
+use crate::presentation::user_output::{UserOutput, VerbosityLevel};
+
+/// Helper to create test `UserOutput`
+fn create_test_user_output() -> Arc<Mutex<UserOutput>> {
+    Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Normal)))
+}
 
 #[test]
 fn it_should_generate_template_with_default_path() {
@@ -13,8 +21,9 @@ fn it_should_generate_template_with_default_path() {
     std::env::set_current_dir(test_context.working_dir()).unwrap();
 
     let action = CreateAction::Template { output_path: None };
+    let user_output = create_test_user_output();
 
-    let result = create::handle_create_command(action, test_context.working_dir());
+    let result = create::handle_create_command(action, test_context.working_dir(), &user_output);
 
     // Restore original directory
     std::env::set_current_dir(original_dir).unwrap();
@@ -56,8 +65,9 @@ fn it_should_generate_template_with_custom_path() {
     let action = CreateAction::Template {
         output_path: Some(custom_path.clone()),
     };
+    let user_output = create_test_user_output();
 
-    let result = create::handle_create_command(action, test_context.working_dir());
+    let result = create::handle_create_command(action, test_context.working_dir(), &user_output);
 
     assert!(result.is_ok(), "Template generation should succeed");
 
@@ -80,8 +90,9 @@ fn it_should_generate_valid_json_template() {
     let action = CreateAction::Template {
         output_path: Some(template_path.clone()),
     };
+    let user_output = create_test_user_output();
 
-    create::handle_create_command(action, test_context.working_dir()).unwrap();
+    create::handle_create_command(action, test_context.working_dir(), &user_output).unwrap();
 
     // Read and parse the generated template
     let file_content = std::fs::read_to_string(&template_path).unwrap();
@@ -124,8 +135,9 @@ fn it_should_create_parent_directories() {
     let action = CreateAction::Template {
         output_path: Some(deep_path.clone()),
     };
+    let user_output = create_test_user_output();
 
-    let result = create::handle_create_command(action, test_context.working_dir());
+    let result = create::handle_create_command(action, test_context.working_dir(), &user_output);
 
     assert!(result.is_ok(), "Should create parent directories");
     assert!(

--- a/src/presentation/commands/destroy/errors.rs
+++ b/src/presentation/commands/destroy/errors.rs
@@ -75,11 +75,14 @@ impl DestroySubcommandError {
     /// # Example
     ///
     /// ```rust
-    /// use torrust_tracker_deployer_lib::presentation::commands::destroy;
     /// use std::path::Path;
+    /// use std::sync::{Arc, Mutex};
+    /// use torrust_tracker_deployer_lib::presentation::commands::destroy;
+    /// use torrust_tracker_deployer_lib::presentation::user_output::{UserOutput, VerbosityLevel};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// if let Err(e) = destroy::handle_destroy_command("test-env", Path::new(".")) {
+    /// let output = Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Normal)));
+    /// if let Err(e) = destroy::handle_destroy_command("test-env", Path::new("."), &output) {
     ///     eprintln!("Error: {e}");
     ///     eprintln!("\nTroubleshooting:\n{}", e.help());
     /// }

--- a/src/presentation/commands/destroy/errors.rs
+++ b/src/presentation/commands/destroy/errors.rs
@@ -91,6 +91,16 @@ Tip: This is a critical bug - please report it with full logs using --log-output
     },
 }
 
+// ============================================================================
+// ERROR CONVERSIONS
+// ============================================================================
+
+impl From<ProgressReporterError> for DestroySubcommandError {
+    fn from(source: ProgressReporterError) -> Self {
+        Self::ProgressReportingFailed { source }
+    }
+}
+
 impl DestroySubcommandError {
     /// Get detailed troubleshooting guidance for this error
     ///

--- a/src/presentation/commands/destroy/handler.rs
+++ b/src/presentation/commands/destroy/handler.rs
@@ -40,6 +40,11 @@ use super::errors::DestroySubcommandError;
 /// the environment cannot be loaded, or the destruction process fails.
 /// All errors include detailed context and actionable troubleshooting guidance.
 ///
+/// # Panics
+///
+/// This function will panic if the `UserOutput` mutex is poisoned. This can only
+/// occur if a panic happened while another thread held the mutex lock.
+///
 /// # Example
 ///
 /// ```rust

--- a/src/presentation/commands/destroy/handler.rs
+++ b/src/presentation/commands/destroy/handler.rs
@@ -6,7 +6,6 @@
 use std::sync::{Arc, Mutex};
 
 use crate::domain::environment::name::EnvironmentName;
-use crate::presentation::commands::context::report_error;
 use crate::presentation::commands::factory::CommandHandlerFactory;
 use crate::presentation::progress::ProgressReporter;
 use crate::presentation::user_output::UserOutput;
@@ -75,7 +74,11 @@ pub fn handle_destroy_command(
             name: environment_name.to_string(),
             source,
         };
-        report_error(progress.output(), &error);
+        progress
+            .output()
+            .lock()
+            .expect("UserOutput mutex poisoned")
+            .error(&error.to_string());
         error
     })?;
     progress.complete_step(Some(&format!(
@@ -94,7 +97,11 @@ pub fn handle_destroy_command(
             name: environment_name.to_string(),
             source,
         };
-        report_error(progress.output(), &error);
+        progress
+            .output()
+            .lock()
+            .expect("UserOutput mutex poisoned")
+            .error(&error.to_string());
         error
     })?;
     progress.complete_step(Some("Infrastructure torn down"));

--- a/src/presentation/commands/destroy/handler.rs
+++ b/src/presentation/commands/destroy/handler.rs
@@ -66,7 +66,7 @@ pub fn handle_destroy_command(
     let ctx = factory.create_context(working_dir.to_path_buf(), user_output.clone());
 
     // Create progress reporter for 3 main steps
-    let mut progress = ProgressReporter::new(ctx.into_user_output(), 3);
+    let mut progress = ProgressReporter::new(user_output.clone(), 3);
 
     // Step 1: Validate environment name
     progress.start_step("Validating environment");
@@ -84,7 +84,6 @@ pub fn handle_destroy_command(
 
     // Step 2: Initialize dependencies
     progress.start_step("Initializing dependencies");
-    let ctx = factory.create_context(working_dir.to_path_buf(), user_output.clone());
     let command_handler = factory.create_destroy_handler(&ctx);
     progress.complete_step(None);
 

--- a/src/presentation/commands/destroy/handler.rs
+++ b/src/presentation/commands/destroy/handler.rs
@@ -65,7 +65,7 @@ pub fn handle_destroy_command(
     let ctx = factory.create_context(working_dir.to_path_buf(), user_output.clone());
 
     // Create progress reporter for 3 main steps
-    let mut progress = ProgressReporter::new(user_output.clone(), 3);
+    let mut progress = ProgressReporter::new(ctx.user_output().clone(), 3);
 
     // Step 1: Validate environment name
     progress.start_step("Validating environment")?;

--- a/src/presentation/commands/destroy/handler.rs
+++ b/src/presentation/commands/destroy/handler.rs
@@ -68,50 +68,36 @@ pub fn handle_destroy_command(
     let mut progress = ProgressReporter::new(user_output.clone(), 3);
 
     // Step 1: Validate environment name
-    progress
-        .start_step("Validating environment")
-        .map_err(|e| DestroySubcommandError::ProgressReportingFailed { source: e })?;
+    progress.start_step("Validating environment")?;
     let env_name = EnvironmentName::new(environment_name.to_string()).map_err(|source| {
         DestroySubcommandError::InvalidEnvironmentName {
             name: environment_name.to_string(),
             source,
         }
     })?;
-    progress
-        .complete_step(Some(&format!(
-            "Environment name validated: {environment_name}"
-        )))
-        .map_err(|e| DestroySubcommandError::ProgressReportingFailed { source: e })?;
+    progress.complete_step(Some(&format!(
+        "Environment name validated: {environment_name}"
+    )))?;
 
     // Step 2: Initialize dependencies
-    progress
-        .start_step("Initializing dependencies")
-        .map_err(|e| DestroySubcommandError::ProgressReportingFailed { source: e })?;
+    progress.start_step("Initializing dependencies")?;
     let command_handler = factory.create_destroy_handler(&ctx);
-    progress
-        .complete_step(None)
-        .map_err(|e| DestroySubcommandError::ProgressReportingFailed { source: e })?;
+    progress.complete_step(None)?;
 
     // Step 3: Execute destroy command (tear down infrastructure)
-    progress
-        .start_step("Tearing down infrastructure")
-        .map_err(|e| DestroySubcommandError::ProgressReportingFailed { source: e })?;
+    progress.start_step("Tearing down infrastructure")?;
     let _destroyed_env = command_handler.execute(&env_name).map_err(|source| {
         DestroySubcommandError::DestroyOperationFailed {
             name: environment_name.to_string(),
             source,
         }
     })?;
-    progress
-        .complete_step(Some("Infrastructure torn down"))
-        .map_err(|e| DestroySubcommandError::ProgressReportingFailed { source: e })?;
+    progress.complete_step(Some("Infrastructure torn down"))?;
 
     // Complete with summary
-    progress
-        .complete(&format!(
-            "Environment '{environment_name}' destroyed successfully"
-        ))
-        .map_err(|e| DestroySubcommandError::ProgressReportingFailed { source: e })?;
+    progress.complete(&format!(
+        "Environment '{environment_name}' destroyed successfully"
+    ))?;
 
     Ok(())
 }

--- a/src/presentation/commands/destroy/handler.rs
+++ b/src/presentation/commands/destroy/handler.rs
@@ -3,23 +3,184 @@
 //! This module handles the destroy command execution at the presentation layer,
 //! including environment validation, repository initialization, and user interaction.
 
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
+use crate::application::command_handlers::DestroyCommandHandler;
 use crate::domain::environment::name::EnvironmentName;
+use crate::domain::environment::state::Destroyed;
+use crate::domain::Environment;
+use crate::presentation::commands::context::CommandContext;
 use crate::presentation::commands::factory::CommandHandlerFactory;
 use crate::presentation::progress::ProgressReporter;
 use crate::presentation::user_output::UserOutput;
 
 use super::errors::DestroySubcommandError;
 
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+/// Number of main steps in the destroy workflow
+const DESTROY_WORKFLOW_STEPS: usize = 3;
+
+// ============================================================================
+// PRESENTATION LAYER CONTROLLER
+// ============================================================================
+
+/// Presentation layer controller for destroy command workflow
+///
+/// Coordinates user interaction, progress reporting, and input validation
+/// before delegating to the application layer `DestroyCommandHandler`.
+///
+/// # Responsibilities
+///
+/// - Validate user input (environment name format)
+/// - Show progress updates to the user
+/// - Format success/error messages for display
+/// - Delegate business logic to application layer
+///
+/// # Architecture
+///
+/// This controller sits in the presentation layer and handles all user-facing
+/// concerns. It delegates actual business logic to the application layer's
+/// `DestroyCommandHandler`, maintaining clear separation of concerns.
+pub struct DestroyCommandController {
+    factory: CommandHandlerFactory,
+    ctx: CommandContext,
+    progress: ProgressReporter,
+}
+
+impl DestroyCommandController {
+    /// Create a new destroy command controller
+    ///
+    /// # Arguments
+    ///
+    /// * `working_dir` - Root directory for environment data storage
+    /// * `user_output` - Shared user output service for consistent formatting
+    pub fn new(working_dir: PathBuf, user_output: Arc<Mutex<UserOutput>>) -> Self {
+        let factory = CommandHandlerFactory::new();
+        let ctx = factory.create_context(working_dir, user_output.clone());
+        let progress = ProgressReporter::new(user_output, DESTROY_WORKFLOW_STEPS);
+
+        Self {
+            factory,
+            ctx,
+            progress,
+        }
+    }
+
+    /// Execute the complete destroy workflow
+    ///
+    /// Orchestrates all steps of the destroy command:
+    /// 1. Validate environment name
+    /// 2. Initialize dependencies
+    /// 3. Tear down infrastructure
+    /// 4. Complete with success message
+    ///
+    /// # Arguments
+    ///
+    /// * `environment_name` - The name of the environment to destroy
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Environment name is invalid (format validation fails)
+    /// - Environment cannot be loaded from repository
+    /// - Infrastructure teardown fails
+    /// - Progress reporting encounters a poisoned mutex
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` on success, or a `DestroySubcommandError` if any step fails.
+    #[allow(clippy::result_large_err)]
+    pub fn execute(&mut self, environment_name: &str) -> Result<(), DestroySubcommandError> {
+        let env_name = self.validate_environment_name(environment_name)?;
+        let handler = self.initialize_dependencies()?;
+        let _destroyed = self.tear_down_infrastructure(&handler, &env_name)?;
+        self.complete_workflow(environment_name)?;
+        Ok(())
+    }
+
+    /// Validate the environment name format
+    ///
+    /// Shows progress to user and validates that the environment name
+    /// meets domain requirements (1-63 chars, alphanumeric + hyphens).
+    #[allow(clippy::result_large_err)]
+    fn validate_environment_name(
+        &mut self,
+        name: &str,
+    ) -> Result<EnvironmentName, DestroySubcommandError> {
+        self.progress.start_step("Validating environment")?;
+
+        let env_name = EnvironmentName::new(name.to_string()).map_err(|source| {
+            DestroySubcommandError::InvalidEnvironmentName {
+                name: name.to_string(),
+                source,
+            }
+        })?;
+
+        self.progress
+            .complete_step(Some(&format!("Environment name validated: {name}")))?;
+
+        Ok(env_name)
+    }
+
+    /// Initialize application layer dependencies
+    ///
+    /// Creates the application layer command handler with all required
+    /// dependencies (repository, clock, etc.).
+    #[allow(clippy::result_large_err)]
+    fn initialize_dependencies(&mut self) -> Result<DestroyCommandHandler, DestroySubcommandError> {
+        self.progress.start_step("Initializing dependencies")?;
+        let handler = self.factory.create_destroy_handler(&self.ctx);
+        self.progress.complete_step(None)?;
+        Ok(handler)
+    }
+
+    /// Execute infrastructure teardown via application layer
+    ///
+    /// Delegates to the application layer `DestroyCommandHandler` to
+    /// orchestrate the actual infrastructure destruction workflow.
+    #[allow(clippy::result_large_err)]
+    fn tear_down_infrastructure(
+        &mut self,
+        handler: &DestroyCommandHandler,
+        env_name: &EnvironmentName,
+    ) -> Result<Environment<Destroyed>, DestroySubcommandError> {
+        self.progress.start_step("Tearing down infrastructure")?;
+
+        let destroyed = handler.execute(env_name).map_err(|source| {
+            DestroySubcommandError::DestroyOperationFailed {
+                name: env_name.to_string(),
+                source,
+            }
+        })?;
+
+        self.progress
+            .complete_step(Some("Infrastructure torn down"))?;
+        Ok(destroyed)
+    }
+
+    /// Complete the workflow with success message
+    ///
+    /// Shows final success message to the user with workflow summary.
+    #[allow(clippy::result_large_err)]
+    fn complete_workflow(&mut self, name: &str) -> Result<(), DestroySubcommandError> {
+        self.progress
+            .complete(&format!("Environment '{name}' destroyed successfully"))?;
+        Ok(())
+    }
+}
+
+// ============================================================================
+// PUBLIC ENTRY POINT
+// ============================================================================
+
 /// Handle the destroy command
 ///
-/// This function orchestrates the environment destruction workflow with progress reporting:
-/// 1. Validating the environment name
-/// 2. Tearing down infrastructure
-/// 3. Cleaning up resources
-///
-/// Each step is tracked and timed using `ProgressReporter` for clear user feedback.
+/// This is a thin wrapper over `DestroyCommandController` that serves as
+/// the public entry point for the destroy command.
 ///
 /// # Arguments
 ///
@@ -27,18 +188,19 @@ use super::errors::DestroySubcommandError;
 /// * `working_dir` - Root directory for environment data storage
 /// * `user_output` - Shared user output service for consistent output formatting
 ///
-/// # Returns
-///
-/// Returns `Ok(())` on success, or a `DestroySubcommandError` if:
-/// - Environment name is invalid
-/// - Environment cannot be loaded
-/// - Destruction fails
-///
 /// # Errors
 ///
-/// This function will return an error if the environment name is invalid,
-/// the environment cannot be loaded, or the destruction process fails.
+/// Returns an error if:
+/// - Environment name is invalid (format validation fails)
+/// - Environment cannot be loaded from repository
+/// - Infrastructure teardown fails
+/// - Progress reporting encounters a poisoned mutex
+///
 /// All errors include detailed context and actionable troubleshooting guidance.
+///
+/// # Returns
+///
+/// Returns `Ok(())` on success, or a `DestroySubcommandError` on failure.
 ///
 /// # Example
 ///
@@ -60,47 +222,13 @@ pub fn handle_destroy_command(
     working_dir: &std::path::Path,
     user_output: &Arc<Mutex<UserOutput>>,
 ) -> Result<(), DestroySubcommandError> {
-    // Create factory and context with all shared dependencies
-    let factory = CommandHandlerFactory::new();
-    let ctx = factory.create_context(working_dir.to_path_buf(), user_output.clone());
-
-    // Create progress reporter for 3 main steps
-    let mut progress = ProgressReporter::new(ctx.user_output().clone(), 3);
-
-    // Step 1: Validate environment name
-    progress.start_step("Validating environment")?;
-    let env_name = EnvironmentName::new(environment_name.to_string()).map_err(|source| {
-        DestroySubcommandError::InvalidEnvironmentName {
-            name: environment_name.to_string(),
-            source,
-        }
-    })?;
-    progress.complete_step(Some(&format!(
-        "Environment name validated: {environment_name}"
-    )))?;
-
-    // Step 2: Initialize dependencies
-    progress.start_step("Initializing dependencies")?;
-    let command_handler = factory.create_destroy_handler(&ctx);
-    progress.complete_step(None)?;
-
-    // Step 3: Execute destroy command (tear down infrastructure)
-    progress.start_step("Tearing down infrastructure")?;
-    let _destroyed_env = command_handler.execute(&env_name).map_err(|source| {
-        DestroySubcommandError::DestroyOperationFailed {
-            name: environment_name.to_string(),
-            source,
-        }
-    })?;
-    progress.complete_step(Some("Infrastructure torn down"))?;
-
-    // Complete with summary
-    progress.complete(&format!(
-        "Environment '{environment_name}' destroyed successfully"
-    ))?;
-
-    Ok(())
+    DestroyCommandController::new(working_dir.to_path_buf(), user_output.clone())
+        .execute(environment_name)
 }
+
+// ============================================================================
+// TESTS
+// ============================================================================
 
 #[cfg(test)]
 mod tests {

--- a/src/presentation/commands/destroy/mod.rs
+++ b/src/presentation/commands/destroy/mod.rs
@@ -18,9 +18,12 @@
 //!
 //! ```rust,no_run
 //! use std::path::Path;
+//! use std::sync::{Arc, Mutex};
 //! use torrust_tracker_deployer_lib::presentation::commands::destroy;
+//! use torrust_tracker_deployer_lib::presentation::user_output::{UserOutput, VerbosityLevel};
 //!
-//! if let Err(e) = destroy::handle_destroy_command("test-env", Path::new(".")) {
+//! let output = Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Normal)));
+//! if let Err(e) = destroy::handle_destroy_command("test-env", Path::new("."), &output) {
 //!     eprintln!("Destroy failed: {e}");
 //!     eprintln!("\n{}", e.help());
 //! }

--- a/src/presentation/commands/factory.rs
+++ b/src/presentation/commands/factory.rs
@@ -32,14 +32,17 @@
 //!
 //! ```rust
 //! use std::path::Path;
+//! use std::sync::{Arc, Mutex};
 //! use torrust_tracker_deployer_lib::presentation::commands::factory::CommandHandlerFactory;
+//! use torrust_tracker_deployer_lib::presentation::user_output::{UserOutput, VerbosityLevel};
 //!
 //! fn handle_command(working_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
 //!     // Create factory with default configuration
 //!     let factory = CommandHandlerFactory::new();
+//!     let output = Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Normal)));
 //!     
 //!     // Create command context
-//!     let context = factory.create_context(working_dir.to_path_buf());
+//!     let context = factory.create_context(working_dir.to_path_buf(), output);
 //!     
 //!     // Create command handler
 //!     let handler = factory.create_create_handler(&context);
@@ -50,9 +53,11 @@
 //! ```
 
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 
 use crate::application::command_handlers::{CreateCommandHandler, DestroyCommandHandler};
 use crate::infrastructure::persistence::repository_factory::RepositoryFactory;
+use crate::presentation::user_output::UserOutput;
 
 use super::constants::DEFAULT_LOCK_TIMEOUT;
 use super::context::CommandContext;
@@ -70,10 +75,13 @@ use super::context::CommandContext;
 ///
 /// ```rust
 /// use std::path::PathBuf;
+/// use std::sync::{Arc, Mutex};
 /// use torrust_tracker_deployer_lib::presentation::commands::factory::CommandHandlerFactory;
+/// use torrust_tracker_deployer_lib::presentation::user_output::{UserOutput, VerbosityLevel};
 ///
 /// let factory = CommandHandlerFactory::new();
-/// let context = factory.create_context(PathBuf::from("."));
+/// let output = Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Normal)));
+/// let context = factory.create_context(PathBuf::from("."), output);
 /// let handler = factory.create_create_handler(&context);
 /// ```
 pub struct CommandHandlerFactory {
@@ -119,14 +127,21 @@ impl CommandHandlerFactory {
     ///
     /// ```rust
     /// use std::path::PathBuf;
+    /// use std::sync::{Arc, Mutex};
     /// use torrust_tracker_deployer_lib::presentation::commands::factory::CommandHandlerFactory;
+    /// use torrust_tracker_deployer_lib::presentation::user_output::{UserOutput, VerbosityLevel};
     ///
     /// let factory = CommandHandlerFactory::new();
-    /// let context = factory.create_context(PathBuf::from("./data"));
+    /// let user_output = Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Normal)));
+    /// let context = factory.create_context(PathBuf::from("./data"), user_output);
     /// ```
     #[must_use]
-    pub fn create_context(&self, working_dir: PathBuf) -> CommandContext {
-        CommandContext::new_with_factory(&self.repository_factory, working_dir)
+    pub fn create_context(
+        &self,
+        working_dir: PathBuf,
+        user_output: Arc<Mutex<UserOutput>>,
+    ) -> CommandContext {
+        CommandContext::new_with_factory(&self.repository_factory, working_dir, user_output)
     }
 
     /// Create a create command handler
@@ -145,10 +160,13 @@ impl CommandHandlerFactory {
     ///
     /// ```rust
     /// use std::path::PathBuf;
+    /// use std::sync::{Arc, Mutex};
     /// use torrust_tracker_deployer_lib::presentation::commands::factory::CommandHandlerFactory;
+    /// use torrust_tracker_deployer_lib::presentation::user_output::{UserOutput, VerbosityLevel};
     ///
     /// let factory = CommandHandlerFactory::new();
-    /// let context = factory.create_context(PathBuf::from("."));
+    /// let output = Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Normal)));
+    /// let context = factory.create_context(PathBuf::from("."), output);
     /// let handler = factory.create_create_handler(&context);
     /// ```
     #[must_use]
@@ -172,10 +190,13 @@ impl CommandHandlerFactory {
     ///
     /// ```rust
     /// use std::path::PathBuf;
+    /// use std::sync::{Arc, Mutex};
     /// use torrust_tracker_deployer_lib::presentation::commands::factory::CommandHandlerFactory;
+    /// use torrust_tracker_deployer_lib::presentation::user_output::{UserOutput, VerbosityLevel};
     ///
     /// let factory = CommandHandlerFactory::new();
-    /// let context = factory.create_context(PathBuf::from("."));
+    /// let output = Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Normal)));
+    /// let context = factory.create_context(PathBuf::from("."), output);
     /// let handler = factory.create_destroy_handler(&context);
     /// ```
     #[must_use]
@@ -221,7 +242,13 @@ impl CommandHandlerFactory {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::presentation::user_output::VerbosityLevel;
     use tempfile::TempDir;
+
+    /// Test helper to create a test user output
+    fn create_test_user_output() -> Arc<Mutex<UserOutput>> {
+        Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Normal)))
+    }
 
     #[test]
     fn it_should_create_factory_with_default_configuration() {
@@ -246,8 +273,9 @@ mod tests {
         let factory = CommandHandlerFactory::new();
         let temp_dir = TempDir::new().unwrap();
         let working_dir = temp_dir.path().to_path_buf();
+        let user_output = create_test_user_output();
 
-        let context = factory.create_context(working_dir);
+        let context = factory.create_context(working_dir, user_output);
 
         // Verify context is created with dependencies
         let _ = context.repository();
@@ -259,8 +287,9 @@ mod tests {
         let factory = CommandHandlerFactory::new();
         let temp_dir = TempDir::new().unwrap();
         let working_dir = temp_dir.path().to_path_buf();
+        let user_output = create_test_user_output();
 
-        let context = factory.create_context(working_dir);
+        let context = factory.create_context(working_dir, user_output);
         let _handler = factory.create_create_handler(&context);
 
         // Verify handler is created (basic structure test)
@@ -271,8 +300,9 @@ mod tests {
         let factory = CommandHandlerFactory::new();
         let temp_dir = TempDir::new().unwrap();
         let working_dir = temp_dir.path().to_path_buf();
+        let user_output = create_test_user_output();
 
-        let context = factory.create_context(working_dir);
+        let context = factory.create_context(working_dir, user_output);
         let _handler = factory.create_destroy_handler(&context);
 
         // Verify handler is created (basic structure test)
@@ -285,8 +315,8 @@ mod tests {
         let working_dir = temp_dir.path().to_path_buf();
 
         // Should be able to create multiple contexts
-        let context1 = factory.create_context(working_dir.clone());
-        let context2 = factory.create_context(working_dir);
+        let context1 = factory.create_context(working_dir.clone(), create_test_user_output());
+        let context2 = factory.create_context(working_dir, create_test_user_output());
 
         // Both contexts should be functional
         let _ = context1.repository();
@@ -298,8 +328,9 @@ mod tests {
         let factory = CommandHandlerFactory::new();
         let temp_dir = TempDir::new().unwrap();
         let working_dir = temp_dir.path().to_path_buf();
+        let user_output = create_test_user_output();
 
-        let context = factory.create_context(working_dir);
+        let context = factory.create_context(working_dir, user_output);
 
         // Should be able to create multiple handlers from same context
         let _create_handler = factory.create_create_handler(&context);
@@ -317,9 +348,10 @@ mod tests {
 
         let temp_dir = TempDir::new().unwrap();
         let working_dir = temp_dir.path().to_path_buf();
+        let user_output = create_test_user_output();
 
         // Should be able to create context with custom factory
-        let context = factory.create_context(working_dir);
+        let context = factory.create_context(working_dir, user_output);
         let _ = context.repository();
     }
 }

--- a/src/presentation/commands/factory.rs
+++ b/src/presentation/commands/factory.rs
@@ -250,6 +250,23 @@ mod tests {
         Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Normal)))
     }
 
+    /// Test helper to create a test setup with factory, temp directory, and user output
+    ///
+    /// Returns a tuple of (`CommandHandlerFactory`, `TempDir`, `PathBuf`, `Arc<Mutex<UserOutput>>`)
+    /// The `TempDir` must be kept alive for the duration of the test.
+    fn create_test_setup() -> (
+        CommandHandlerFactory,
+        TempDir,
+        PathBuf,
+        Arc<Mutex<UserOutput>>,
+    ) {
+        let factory = CommandHandlerFactory::new();
+        let temp_dir = TempDir::new().unwrap();
+        let working_dir = temp_dir.path().to_path_buf();
+        let user_output = create_test_user_output();
+        (factory, temp_dir, working_dir, user_output)
+    }
+
     #[test]
     fn it_should_create_factory_with_default_configuration() {
         let factory = CommandHandlerFactory::new();
@@ -270,10 +287,7 @@ mod tests {
 
     #[test]
     fn it_should_create_context_with_factory() {
-        let factory = CommandHandlerFactory::new();
-        let temp_dir = TempDir::new().unwrap();
-        let working_dir = temp_dir.path().to_path_buf();
-        let user_output = create_test_user_output();
+        let (factory, _temp_dir, working_dir, user_output) = create_test_setup();
 
         let context = factory.create_context(working_dir, user_output);
 
@@ -284,10 +298,7 @@ mod tests {
 
     #[test]
     fn it_should_create_create_handler() {
-        let factory = CommandHandlerFactory::new();
-        let temp_dir = TempDir::new().unwrap();
-        let working_dir = temp_dir.path().to_path_buf();
-        let user_output = create_test_user_output();
+        let (factory, _temp_dir, working_dir, user_output) = create_test_setup();
 
         let context = factory.create_context(working_dir, user_output);
         let _handler = factory.create_create_handler(&context);
@@ -297,10 +308,7 @@ mod tests {
 
     #[test]
     fn it_should_create_destroy_handler() {
-        let factory = CommandHandlerFactory::new();
-        let temp_dir = TempDir::new().unwrap();
-        let working_dir = temp_dir.path().to_path_buf();
-        let user_output = create_test_user_output();
+        let (factory, _temp_dir, working_dir, user_output) = create_test_setup();
 
         let context = factory.create_context(working_dir, user_output);
         let _handler = factory.create_destroy_handler(&context);
@@ -310,9 +318,7 @@ mod tests {
 
     #[test]
     fn it_should_create_multiple_contexts_from_same_factory() {
-        let factory = CommandHandlerFactory::new();
-        let temp_dir = TempDir::new().unwrap();
-        let working_dir = temp_dir.path().to_path_buf();
+        let (factory, _temp_dir, working_dir, _user_output) = create_test_setup();
 
         // Should be able to create multiple contexts
         let context1 = factory.create_context(working_dir.clone(), create_test_user_output());
@@ -325,10 +331,7 @@ mod tests {
 
     #[test]
     fn it_should_create_multiple_handlers_from_same_context() {
-        let factory = CommandHandlerFactory::new();
-        let temp_dir = TempDir::new().unwrap();
-        let working_dir = temp_dir.path().to_path_buf();
-        let user_output = create_test_user_output();
+        let (factory, _temp_dir, working_dir, user_output) = create_test_setup();
 
         let context = factory.create_context(working_dir, user_output);
 
@@ -346,9 +349,7 @@ mod tests {
         let repository_factory = RepositoryFactory::new(Duration::from_millis(100));
         let factory = CommandHandlerFactory::new_for_testing(repository_factory);
 
-        let temp_dir = TempDir::new().unwrap();
-        let working_dir = temp_dir.path().to_path_buf();
-        let user_output = create_test_user_output();
+        let (_factory, _temp_dir, working_dir, user_output) = create_test_setup();
 
         // Should be able to create context with custom factory
         let context = factory.create_context(working_dir, user_output);

--- a/src/presentation/commands/mod.rs
+++ b/src/presentation/commands/mod.rs
@@ -144,6 +144,13 @@ pub fn handle_error(error: &CommandError, user_output: &Arc<Mutex<UserOutput>>) 
         output.info_block("For detailed troubleshooting:", &[help_text]);
     } else {
         // Cannot acquire lock - print to stderr directly as fallback
+        //
+        // RATIONALE: Plain text formatting without emojis/styling is intentional.
+        // When the mutex is poisoned, we're in a degraded error state where another
+        // thread has panicked. Using plain eprintln! ensures maximum compatibility
+        // and avoids any additional complexity that could fail in this critical path.
+        // The goal here is reliability over aesthetics - get the error message to
+        // the user no matter what, even if it's not pretty.
         eprintln!("ERROR: {error}");
         eprintln!();
         eprintln!("CRITICAL: Failed to acquire user output lock.");

--- a/src/presentation/commands/tests/mod.rs
+++ b/src/presentation/commands/tests/mod.rs
@@ -27,7 +27,10 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 use tempfile::TempDir;
+
+use crate::presentation::user_output::{UserOutput, VerbosityLevel};
 
 // ============================================================================
 // PUBLIC API - Test Context
@@ -57,6 +60,7 @@ use tempfile::TempDir;
 pub struct TestContext {
     _temp_dir: TempDir,
     working_dir: PathBuf,
+    user_output: Arc<Mutex<UserOutput>>,
 }
 
 impl TestContext {
@@ -69,10 +73,12 @@ impl TestContext {
     pub fn new() -> Self {
         let temp_dir = TempDir::new().expect("Failed to create temporary directory");
         let working_dir = temp_dir.path().to_path_buf();
+        let user_output = Arc::new(Mutex::new(UserOutput::new(VerbosityLevel::Normal)));
 
         Self {
             _temp_dir: temp_dir,
             working_dir,
+            user_output,
         }
     }
 
@@ -83,6 +89,12 @@ impl TestContext {
     #[must_use]
     pub fn working_dir(&self) -> &Path {
         &self.working_dir
+    }
+
+    /// Get a reference to the shared user output
+    #[must_use]
+    pub fn user_output(&self) -> Arc<Mutex<UserOutput>> {
+        Arc::clone(&self.user_output)
     }
 }
 

--- a/src/presentation/errors.rs
+++ b/src/presentation/errors.rs
@@ -42,6 +42,13 @@ pub enum CommandError {
     /// Use `.help()` for detailed troubleshooting steps.
     #[error("Destroy command failed: {0}")]
     Destroy(Box<DestroySubcommandError>),
+
+    /// User output lock acquisition failed
+    ///
+    /// Failed to acquire the mutex lock for user output. This typically indicates
+    /// a panic occurred in another thread while holding the lock.
+    #[error("Failed to acquire user output lock - a panic occurred in another thread while displaying output")]
+    UserOutputLockFailed,
 }
 
 impl From<CreateSubcommandError> for CommandError {
@@ -94,6 +101,27 @@ impl CommandError {
         match self {
             Self::Create(e) => e.help(),
             Self::Destroy(e) => e.help(),
+            Self::UserOutputLockFailed => {
+                "User Output Lock Failed - Detailed Troubleshooting:
+
+This error indicates that a panic occurred in another thread while it was using
+the user output system, leaving the mutex in a \"poisoned\" state.
+
+1. Check for any error messages that appeared before this one
+   - The original panic message should appear earlier in the output
+   - This will indicate what caused the initial failure
+
+2. This is typically caused by:
+   - A bug in the application code that caused a panic
+   - An unhandled error condition that triggered a panic
+   - Resource exhaustion (memory, file handles, etc.)
+
+3. If you can reproduce this issue:
+   - Run with --verbose to see more detailed logging
+   - Report the issue with the full error output and steps to reproduce
+
+This is a serious application error that indicates a bug. Please report it to the developers."
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR centralizes `UserOutput` management via dependency injection, providing better control over output formatting and reducing duplication throughout the codebase.

## Changes

### Core Changes
- ✅ Add `AppContainer` for centralized dependency management (`src/bootstrap/container.rs`)
- ✅ Update all command handlers to accept `&Arc<Mutex<UserOutput>>`
- ✅ Remove `UserOutput` cloning throughout command execution
- ✅ Ensure thread-safe shared ownership of output stream

### Documentation
- ✅ Update all documentation examples to use `Arc<Mutex<UserOutput>>`
- ✅ Fix all doc tests to compile with new API (234 passing)

### Testing
- ✅ Update all tests to use the new pattern
- ✅ All pre-commit checks passing

## Benefits

1. **Centralized Control**: Single point of creation for UserOutput
2. **Thread Safety**: Proper Arc<Mutex<>> wrapper ensures safe concurrent access
3. **Reduced Duplication**: Eliminates cloning throughout the codebase
4. **Better Testing**: Easier to inject mock outputs for testing

## Files Changed (20 files)

- `src/bootstrap/app.rs` - Updated to use AppContainer
- `src/bootstrap/container.rs` - **NEW** - Dependency injection container
- `src/bootstrap/mod.rs` - Module updates
- `src/presentation/commands/context.rs` - Updated API and docs
- `src/presentation/commands/create/*` - Updated create command handlers
- `src/presentation/commands/destroy/*` - Updated destroy command handlers
- `src/presentation/commands/factory.rs` - Updated factory methods
- `src/presentation/commands/mod.rs` - Updated command execution
- `src/presentation/progress.rs` - Updated progress reporting
- Tests updated across all command modules

## Status

- [x] All tests passing
- [x] Documentation updated
- [x] Pre-commit checks passing
- [x] Additional refactors planned (keeping as draft)

## Related

Closes #107