### PR TITLE
docs: migrate to AGENTS.md standard for multi-agent compatibility

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,131 +1,26 @@
-Tracker Deploy - AI Assistant Instructions
+# GitHub Copilot Instructions
 
-**Repository**: [torrust/torrust-tracker-deployer](https://github.com/torrust/torrust-tracker-deployer)
+> **Note**: This repository has migrated to the [AGENTS.md](../AGENTS.md) standard for AI agent instructions.
+>
+> The AGENTS.md standard is an open format supported by multiple AI coding agents (GitHub Copilot, Cursor, Aider, Jules, and more). For more information about this standard, see https://agents.md
 
-## 📋 Project Overview
+## 📄 Primary Instructions Location
 
-This is a deployment infrastructure proof-of-concept for the Torrust ecosystem. It uses OpenTofu (Terraform), Ansible, and Rust to provision and manage deployment environments with LXD VM instances.
+**All AI agent instructions for this repository are now in [`AGENTS.md`](../AGENTS.md)** at the repository root.
 
-### Architecture
+GitHub Copilot will continue to work with this repository by reading the `AGENTS.md` file, which is fully supported as of August 28, 2025.
 
-- **DDD Layers**: The codebase follows Domain-Driven Design with `domain/` (business logic), `application/` (use cases and commands), and `infrastructure/` (external integrations) layers.
-- **Three-Level Pattern**: Commands orchestrate Steps, which execute remote Actions - providing clear separation of concerns across deployment operations (see `docs/codebase-architecture.md`).
+## 🔄 Migration Information
 
-## 🏗️ Tech Stack
+This file is kept for backward compatibility and to inform GitHub Copilot users about the migration. The `AGENTS.md` format provides:
 
-- **Languages**: Rust, Shell scripts, YAML, TOML
-- **Infrastructure**: OpenTofu (Terraform), Ansible
-- **Virtualization Providers**: LXD VM instances
-- **Tools**: Docker, cloud-init, testcontainers
-- **Linting Tools**: markdownlint, yamllint, shellcheck, clippy, rustfmt, taplo (TOML)
+- **Multi-agent compatibility**: Works with any AI coding agent that supports the standard
+- **Industry standard**: Open format maintained by the community
+- **Nested support**: Can be placed in subdirectories for monorepo projects
+- **Future-proof**: Not tied to any specific vendor
 
-## 📁 Key Directories
+## 📚 Resources
 
-- `src/` - Rust source code organized by DDD layers (`domain/`, `application/`, `infrastructure/`, `presentation/`, `shared/`)
-- `src/bin/` - Binary executables (linter, E2E tests, dependency installer)
-- `data/` - Environment-specific data and source templates
-- `templates/` - Generated template examples and test fixtures
-- `build/` - Generated runtime configurations (git-ignored)
-- `docs/` - Project documentation
-- `docs/user-guide/` - User-facing documentation (getting started, commands, configuration)
-- `docs/decisions/` - Architectural Decision Records (ADRs)
-- `scripts/` - Shell scripts for development tasks
-- `fixtures/` - Test data and keys for development
-- `packages/` - Rust workspace packages (see `packages/README.md` for details)
-  - `dependency-installer/` - Dependency detection and installation for development setup
-  - `linting/` - Unified linting framework
-
-## 📄 Key Configuration Files
-
-- `.markdownlint.json` - Markdown linting rules
-- `.yamllint-ci.yml` - YAML linting configuration
-- `.taplo.toml` - TOML formatting and linting
-- `cspell.json` - Spell checking configuration
-- `project-words.txt` - Project-specific dictionary
-
-## Essential Principles
-
-The development of this application is guided by fundamental principles that ensure quality, maintainability, and user experience. For detailed information, see [`docs/development-principles.md`](../docs/development-principles.md).
-
-**Core Principles:**
-
-- **Observability**: If it happens, we can see it - even after it happens (includes deep traceability)
-- **Testability**: Every component must be testable in isolation and as part of the whole
-- **User Friendliness**: All errors must be clear, informative, and solution-oriented
-- **Actionability**: The system must always tell users how to continue with detailed instructions
-
-**Code Quality Standards:**
-
-Both production and test code must be:
-
-- **Clean**: Well-structured with clear naming and minimal complexity
-- **Maintainable**: Easy to modify and extend without breaking existing functionality
-- **Sustainable**: Long-term viability with proper documentation and patterns
-- **Readable**: Clear intent that can be understood by other developers
-- **Testable**: Designed to support comprehensive testing at all levels
-
-These principles should guide all development decisions, code reviews, and feature implementations.
-
-## 🔧 Essential Rules
-
-1. **Before placing code in DDD layers**: Read [`docs/contributing/ddd-layer-placement.md`](../docs/contributing/ddd-layer-placement.md) for comprehensive guidance on which code belongs in which layer (Domain, Application, Infrastructure, Presentation). This guide includes rules, red flags, examples, and a decision flowchart to help you make the right architectural decisions.
-
-2. **Before creating branches**: Read [`docs/contributing/branching.md`](../docs/contributing/branching.md) for naming conventions (`{issue-number}-{short-description}`)
-
-3. **Before committing**: Read [`docs/contributing/commit-process.md`](../docs/contributing/commit-process.md) for conventional commits
-
-   - **With issue branch**: `{type}: [#{issue}] {description}` (when branch name starts with `{issue-number}-`)
-   - **Without issue branch**: `{type}: {description}` (when working on main or branch without issue number prefix)
-
-4. **Before committing**: Always run the pre-commit verification script - all checks must pass before staging files or creating commits, regardless of the tool or method used:
-
-   ```bash
-   ./scripts/pre-commit.sh
-   ```
-
-   This applies to **any** method of committing:
-
-   - Terminal: `git add`, `git commit`, `git commit -am`, `cd ../ && git add ...`, `git add . && git commit -m "..."`
-   - VS Code: Git panel, Source Control view, commit shortcuts
-   - IDEs: IntelliJ, CLion, RustRover git integration
-   - Git clients: GitHub Desktop, GitKraken, etc.
-   - CI/CD: Any automated commits or merges
-
-5. **Before working with Tera templates**: Read [`docs/contributing/templates.md`](../docs/contributing/templates.md) for correct variable syntax - use `{{ variable }}` not `{ { variable } }`. Tera template files have the `.tera` extension.
-
-6. **When adding new Ansible playbooks**: Read [`docs/contributing/templates.md`](../docs/contributing/templates.md) for the complete guide. **CRITICAL**: Static playbooks (without `.tera` extension) must be registered in `src/infrastructure/external_tools/ansible/template/renderer/mod.rs` in the `copy_static_templates` method, otherwise they won't be copied to the build directory and Ansible will fail with "playbook not found" error.
-
-7. **When handling errors in code**: Read [`docs/contributing/error-handling.md`](../docs/contributing/error-handling.md) for error handling principles. Prefer explicit enum errors over anyhow for better pattern matching and user experience. Make errors clear, include sufficient context for traceability, and ensure they are actionable with specific fix instructions.
-
-8. **Understanding expected errors**: Read [`docs/contributing/known-issues.md`](../docs/contributing/known-issues.md) for known issues and expected behaviors. Some errors that appear red in E2E test output (like SSH host key warnings) are normal and expected - not actual failures.
-
-9. **Before making engineering decisions**: Document significant architectural or design decisions as Architectural Decision Records (ADRs) in `docs/decisions/`. Read [`docs/decisions/README.md`](../docs/decisions/README.md) for the ADR template and guidelines. This ensures decisions are properly documented with context, rationale, and consequences for future reference.
-
-10. **When organizing code within modules**: Follow the module organization conventions in [`docs/contributing/module-organization.md`](../docs/contributing/module-organization.md). Use top-down organization with public items first, high-level abstractions before low-level details, and important responsibilities before secondary concerns like error types. **Prefer imports over full namespace paths** - always import types and use short names (e.g., `Arc<UserOutput>`) unless disambiguating name conflicts. Never use long paths like `std::sync::Arc<crate::presentation::views::UserOutput>` in regular code.
-
-11. **When writing Markdown documentation**: Be aware of GitHub Flavored Markdown's automatic linking behavior. Read [`docs/contributing/github-markdown-pitfalls.md`](../docs/contributing/github-markdown-pitfalls.md) for critical patterns to avoid. **NEVER use hash-number patterns for enumeration or step numbering** - this creates unintended links to GitHub issues/PRs. Use ordered lists or alternative formats instead.
-
-12. **When creating new environment variables**: Read [`docs/contributing/environment-variables-naming.md`](../docs/contributing/environment-variables-naming.md) for comprehensive guidance on naming conventions (condition-based vs action-based), decision frameworks, and best practices. Also review [`docs/decisions/environment-variable-prefix.md`](../docs/decisions/environment-variable-prefix.md) to ensure all project environment variables use the `TORRUST_TD_` prefix for proper namespacing and avoiding conflicts with system or user variables.
-
-## 🧪 Build & Test
-
-- **Setup Dependencies**: `cargo run --bin dependency-installer install` (sets up required development tools)
-  - **Check dependencies**: `cargo run --bin dependency-installer check` (verifies installation)
-  - **List dependencies**: `cargo run --bin dependency-installer list` (shows all dependencies with status)
-  - Required tools: OpenTofu, Ansible, LXD, cargo-machete
-  - See [`packages/dependency-installer/README.md`](../packages/dependency-installer/README.md) for details
-- **Lint**: `cargo run --bin linter all` (comprehensive - tests stable & nightly toolchains)
-  - Individual linters: `cargo run --bin linter {markdown|yaml|toml|cspell|clippy|rustfmt|shellcheck}`
-  - Alternative: `./scripts/lint.sh` (wrapper that calls the Rust binary)
-- **Dependencies**: `cargo machete` (mandatory before commits - no unused dependencies)
-- **Build**: `cargo build`
-- **Test**: `cargo test`
-- **Unit Tests**: When writing unit tests, follow conventions described in [`docs/contributing/testing/`](../docs/contributing/testing/)
-- **E2E Tests**:
-  - `cargo run --bin e2e-tests-full` - Comprehensive tests (⚠️ **LOCAL ONLY** - cannot run on GitHub Actions due to network connectivity issues)
-  - `cargo run --bin e2e-provision-and-destroy-tests` - Infrastructure provisioning and destruction tests (GitHub runner-compatible)
-  - `cargo run --bin e2e-config-tests` - Software installation and configuration tests (GitHub runner-compatible)
-  - Pre-commit hook runs the split tests (`e2e-provision-and-destroy-tests` + `e2e-config-tests`) for GitHub Copilot compatibility
-  - See [`docs/e2e-testing.md`](../docs/e2e-testing.md) for detailed information about CI limitations
-
-Follow the project conventions and ensure all checks pass.
+- **Project Instructions**: See [`AGENTS.md`](../AGENTS.md) for complete AI agent instructions
+- **AGENTS.md Standard**: Learn more at https://agents.md
+- **GitHub Documentation**: https://docs.github.com/en/copilot/concepts/prompting/response-customization

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,131 @@
+# Tracker Deploy - AI Assistant Instructions
+
+**Repository**: [torrust/torrust-tracker-deployer](https://github.com/torrust/torrust-tracker-deployer)
+
+## 📋 Project Overview
+
+This is a deployment infrastructure proof-of-concept for the Torrust ecosystem. It uses OpenTofu (Terraform), Ansible, and Rust to provision and manage deployment environments with LXD VM instances.
+
+### Architecture
+
+- **DDD Layers**: The codebase follows Domain-Driven Design with `domain/` (business logic), `application/` (use cases and commands), and `infrastructure/` (external integrations) layers.
+- **Three-Level Pattern**: Commands orchestrate Steps, which execute remote Actions - providing clear separation of concerns across deployment operations (see `docs/codebase-architecture.md`).
+
+## 🏗️ Tech Stack
+
+- **Languages**: Rust, Shell scripts, YAML, TOML
+- **Infrastructure**: OpenTofu (Terraform), Ansible
+- **Virtualization Providers**: LXD VM instances
+- **Tools**: Docker, cloud-init, testcontainers
+- **Linting Tools**: markdownlint, yamllint, shellcheck, clippy, rustfmt, taplo (TOML)
+
+## 📁 Key Directories
+
+- `src/` - Rust source code organized by DDD layers (`domain/`, `application/`, `infrastructure/`, `presentation/`, `shared/`)
+- `src/bin/` - Binary executables (linter, E2E tests, dependency installer)
+- `data/` - Environment-specific data and source templates
+- `templates/` - Generated template examples and test fixtures
+- `build/` - Generated runtime configurations (git-ignored)
+- `docs/` - Project documentation
+- `docs/user-guide/` - User-facing documentation (getting started, commands, configuration)
+- `docs/decisions/` - Architectural Decision Records (ADRs)
+- `scripts/` - Shell scripts for development tasks
+- `fixtures/` - Test data and keys for development
+- `packages/` - Rust workspace packages (see `packages/README.md` for details)
+  - `dependency-installer/` - Dependency detection and installation for development setup
+  - `linting/` - Unified linting framework
+
+## 📄 Key Configuration Files
+
+- `.markdownlint.json` - Markdown linting rules
+- `.yamllint-ci.yml` - YAML linting configuration
+- `.taplo.toml` - TOML formatting and linting
+- `cspell.json` - Spell checking configuration
+- `project-words.txt` - Project-specific dictionary
+
+## Essential Principles
+
+The development of this application is guided by fundamental principles that ensure quality, maintainability, and user experience. For detailed information, see [`docs/development-principles.md`](docs/development-principles.md).
+
+**Core Principles:**
+
+- **Observability**: If it happens, we can see it - even after it happens (includes deep traceability)
+- **Testability**: Every component must be testable in isolation and as part of the whole
+- **User Friendliness**: All errors must be clear, informative, and solution-oriented
+- **Actionability**: The system must always tell users how to continue with detailed instructions
+
+**Code Quality Standards:**
+
+Both production and test code must be:
+
+- **Clean**: Well-structured with clear naming and minimal complexity
+- **Maintainable**: Easy to modify and extend without breaking existing functionality
+- **Sustainable**: Long-term viability with proper documentation and patterns
+- **Readable**: Clear intent that can be understood by other developers
+- **Testable**: Designed to support comprehensive testing at all levels
+
+These principles should guide all development decisions, code reviews, and feature implementations.
+
+## 🔧 Essential Rules
+
+1. **Before placing code in DDD layers**: Read [`docs/contributing/ddd-layer-placement.md`](docs/contributing/ddd-layer-placement.md) for comprehensive guidance on which code belongs in which layer (Domain, Application, Infrastructure, Presentation). This guide includes rules, red flags, examples, and a decision flowchart to help you make the right architectural decisions.
+
+2. **Before creating branches**: Read [`docs/contributing/branching.md`](docs/contributing/branching.md) for naming conventions (`{issue-number}-{short-description}`)
+
+3. **Before committing**: Read [`docs/contributing/commit-process.md`](docs/contributing/commit-process.md) for conventional commits
+
+   - **With issue branch**: `{type}: [#{issue}] {description}` (when branch name starts with `{issue-number}-`)
+   - **Without issue branch**: `{type}: {description}` (when working on main or branch without issue number prefix)
+
+4. **Before committing**: Always run the pre-commit verification script - all checks must pass before staging files or creating commits, regardless of the tool or method used:
+
+   ```bash
+   ./scripts/pre-commit.sh
+   ```
+
+   This applies to **any** method of committing:
+
+   - Terminal: `git add`, `git commit`, `git commit -am`, `cd ../ && git add ...`, `git add . && git commit -m "..."`
+   - VS Code: Git panel, Source Control view, commit shortcuts
+   - IDEs: IntelliJ, CLion, RustRover git integration
+   - Git clients: GitHub Desktop, GitKraken, etc.
+   - CI/CD: Any automated commits or merges
+
+5. **Before working with Tera templates**: Read [`docs/contributing/templates.md`](docs/contributing/templates.md) for correct variable syntax - use `{{ variable }}` not `{ { variable } }`. Tera template files have the `.tera` extension.
+
+6. **When adding new Ansible playbooks**: Read [`docs/contributing/templates.md`](docs/contributing/templates.md) for the complete guide. **CRITICAL**: Static playbooks (without `.tera` extension) must be registered in `src/infrastructure/external_tools/ansible/template/renderer/mod.rs` in the `copy_static_templates` method, otherwise they won't be copied to the build directory and Ansible will fail with "playbook not found" error.
+
+7. **When handling errors in code**: Read [`docs/contributing/error-handling.md`](docs/contributing/error-handling.md) for error handling principles. Prefer explicit enum errors over anyhow for better pattern matching and user experience. Make errors clear, include sufficient context for traceability, and ensure they are actionable with specific fix instructions.
+
+8. **Understanding expected errors**: Read [`docs/contributing/known-issues.md`](docs/contributing/known-issues.md) for known issues and expected behaviors. Some errors that appear red in E2E test output (like SSH host key warnings) are normal and expected - not actual failures.
+
+9. **Before making engineering decisions**: Document significant architectural or design decisions as Architectural Decision Records (ADRs) in `docs/decisions/`. Read [`docs/decisions/README.md`](docs/decisions/README.md) for the ADR template and guidelines. This ensures decisions are properly documented with context, rationale, and consequences for future reference.
+
+10. **When organizing code within modules**: Follow the module organization conventions in [`docs/contributing/module-organization.md`](docs/contributing/module-organization.md). Use top-down organization with public items first, high-level abstractions before low-level details, and important responsibilities before secondary concerns like error types. **Prefer imports over full namespace paths** - always import types and use short names (e.g., `Arc<UserOutput>`) unless disambiguating name conflicts. Never use long paths like `std::sync::Arc<crate::presentation::views::UserOutput>` in regular code.
+
+11. **When writing Markdown documentation**: Be aware of GitHub Flavored Markdown's automatic linking behavior. Read [`docs/contributing/github-markdown-pitfalls.md`](docs/contributing/github-markdown-pitfalls.md) for critical patterns to avoid. **NEVER use hash-number patterns for enumeration or step numbering** - this creates unintended links to GitHub issues/PRs. Use ordered lists or alternative formats instead.
+
+12. **When creating new environment variables**: Read [`docs/contributing/environment-variables-naming.md`](docs/contributing/environment-variables-naming.md) for comprehensive guidance on naming conventions (condition-based vs action-based), decision frameworks, and best practices. Also review [`docs/decisions/environment-variable-prefix.md`](docs/decisions/environment-variable-prefix.md) to ensure all project environment variables use the `TORRUST_TD_` prefix for proper namespacing and avoiding conflicts with system or user variables.
+
+## 🧪 Build & Test
+
+- **Setup Dependencies**: `cargo run --bin dependency-installer install` (sets up required development tools)
+  - **Check dependencies**: `cargo run --bin dependency-installer check` (verifies installation)
+  - **List dependencies**: `cargo run --bin dependency-installer list` (shows all dependencies with status)
+  - Required tools: OpenTofu, Ansible, LXD, cargo-machete
+  - See [`packages/dependency-installer/README.md`](packages/dependency-installer/README.md) for details
+- **Lint**: `cargo run --bin linter all` (comprehensive - tests stable & nightly toolchains)
+  - Individual linters: `cargo run --bin linter {markdown|yaml|toml|cspell|clippy|rustfmt|shellcheck}`
+  - Alternative: `./scripts/lint.sh` (wrapper that calls the Rust binary)
+- **Dependencies**: `cargo machete` (mandatory before commits - no unused dependencies)
+- **Build**: `cargo build`
+- **Test**: `cargo test`
+- **Unit Tests**: When writing unit tests, follow conventions described in [`docs/contributing/testing/`](docs/contributing/testing/)
+- **E2E Tests**:
+  - `cargo run --bin e2e-tests-full` - Comprehensive tests (⚠️ **LOCAL ONLY** - cannot run on GitHub Actions due to network connectivity issues)
+  - `cargo run --bin e2e-provision-and-destroy-tests` - Infrastructure provisioning and destruction tests (GitHub runner-compatible)
+  - `cargo run --bin e2e-config-tests` - Software installation and configuration tests (GitHub runner-compatible)
+  - Pre-commit hook runs the split tests (`e2e-provision-and-destroy-tests` + `e2e-config-tests`) for GitHub Copilot compatibility
+  - See [`docs/e2e-testing.md`](docs/e2e-testing.md) for detailed information about CI limitations
+
+Follow the project conventions and ensure all checks pass.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -6,6 +6,7 @@ This directory contains architectural decision records for the Torrust Tracker D
 
 | Status        | Date       | Decision                                                                                            | Summary                                                                                   |
 | ------------- | ---------- | --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| ✅ Accepted   | 2025-11-13 | [Migration to AGENTS.md Standard](./agents-md-migration.md)                                         | Adopt open AGENTS.md standard for multi-agent compatibility while keeping GitHub redirect |
 | ✅ Accepted   | 2025-11-11 | [Use ReentrantMutex Pattern for UserOutput Reentrancy](./reentrant-mutex-useroutput-pattern.md)     | Use Arc<ReentrantMutex<RefCell<UserOutput>>> to fix same-thread deadlock in issue #164    |
 | ❌ Superseded | 2025-11-11 | [Remove UserOutput Mutex](./user-output-mutex-removal.md)                                           | Remove Arc<Mutex<UserOutput>> pattern for simplified, deadlock-free architecture          |
 | ✅ Accepted   | 2025-11-07 | [ExecutionContext Wrapper Pattern](./execution-context-wrapper.md)                                  | Use ExecutionContext wrapper around Container for future-proof command signatures         |

--- a/docs/decisions/agents-md-migration.md
+++ b/docs/decisions/agents-md-migration.md
@@ -1,0 +1,151 @@
+# Decision: Migration to AGENTS.md Standard
+
+## Status
+
+Accepted
+
+## Date
+
+2025-11-13
+
+## Context
+
+The project has been using `.github/copilot-instructions.md` to provide AI agent instructions specifically for GitHub Copilot. However, as AI coding agents have proliferated (Cursor, Aider, Jules, etc.), there is a need for a more universal, agent-agnostic format.
+
+The `AGENTS.md` standard emerged as a collaborative effort across the AI software development ecosystem, supported by multiple major AI coding agents. This open format provides several advantages:
+
+- **Multi-agent compatibility**: Works with GitHub Copilot, Cursor, Aider, Jules from Google, and many others
+- **Industry standard**: Community-maintained open format, not tied to any vendor
+- **Flexibility**: Can be nested in subdirectories for monorepo projects
+- **Future-proof**: Not dependent on any specific vendor's decisions
+- **Wide adoption**: Used by over 20,000 open-source projects
+
+GitHub Copilot officially added support for `AGENTS.md` files on August 28, 2025, alongside their existing `.github/copilot-instructions.md` format.
+
+### Related Issue
+
+This decision addresses [issue #172](https://github.com/torrust/torrust-tracker-deployer/issues/172).
+
+## Decision
+
+We will **migrate to the AGENTS.md standard as the primary source** for AI agent instructions, while keeping `.github/copilot-instructions.md` as a minimal redirect file for backward compatibility.
+
+**Implementation:**
+
+1. Create `AGENTS.md` at repository root with complete AI agent instructions
+2. Replace `.github/copilot-instructions.md` content with a brief notice that:
+   - Points to `AGENTS.md` as the primary location
+   - Explains the migration to the standard format
+   - Provides links to resources about AGENTS.md
+3. Add "AGENTS" to the project spell-check dictionary
+4. Document the migration in this ADR
+
+## Consequences
+
+### Positive
+
+- ✅ **Universal compatibility**: Instructions now work with any AI agent that supports the standard
+- ✅ **Future-proof**: Not locked into GitHub-specific format
+- ✅ **Industry alignment**: Following an emerging community standard
+- ✅ **Backward compatible**: GitHub Copilot users can still find instructions via the redirect
+- ✅ **Better developer experience**: Works seamlessly across different AI coding tools
+- ✅ **Community benefit**: Contributes to the adoption of an open standard
+
+### Negative
+
+- ⚠️ **Two files to maintain**: Must keep redirect file in sync if major changes occur
+- ⚠️ **Potential confusion**: Developers might be confused about which file to edit (mitigated by clear redirect message)
+- ⚠️ **Learning curve**: Teams need to learn about the new standard (minimal - it's just Markdown)
+
+### Neutral
+
+- 📝 **File location change**: Instructions moved from `.github/` to root directory
+- 📝 **Format unchanged**: Both formats use standard Markdown
+- 📝 **Content identical**: Same instructions in both locations initially
+
+## Alternatives Considered
+
+### Option 1: Keep only `.github/copilot-instructions.md` (Rejected)
+
+**Pros:**
+
+- No migration needed
+- GitHub Copilot users already familiar with this location
+
+**Cons:**
+
+- ❌ Locks project into GitHub-specific format
+- ❌ Doesn't work with other AI coding agents
+- ❌ Misses opportunity to adopt industry standard
+
+**Rejected because:** This doesn't address the multi-agent compatibility goal.
+
+### Option 2: Maintain both files with identical content (Considered)
+
+**Pros:**
+
+- Maximum compatibility
+- No potential for confusion
+
+**Cons:**
+
+- ❌ Duplication of content
+- ❌ Higher maintenance burden
+- ❌ Risk of files getting out of sync
+
+**Rejected because:** The redirect approach provides the same benefits with less maintenance overhead.
+
+### Option 3: Delete `.github/copilot-instructions.md` entirely (Considered)
+
+**Pros:**
+
+- Single source of truth
+- Minimal maintenance
+
+**Cons:**
+
+- ❌ Breaking change for users expecting GitHub-specific file
+- ❌ Loses backward compatibility
+- ❌ GitHub Copilot users might be confused
+
+**Rejected because:** Keeping a redirect file provides better user experience with minimal cost.
+
+## Migration Path
+
+For teams adopting this pattern:
+
+1. **Check current state**: Review existing `.github/copilot-instructions.md`
+2. **Create AGENTS.md**: Copy instructions to repository root as `AGENTS.md`
+3. **Update paths**: Change relative paths from `../` to match new location
+4. **Update redirect**: Replace copilot-instructions.md with redirect notice
+5. **Document change**: Update relevant documentation and team communications
+6. **Test**: Verify both GitHub Copilot and other agents can read new instructions
+
+## Related Decisions
+
+- None yet - this is the first ADR related to AI agent instructions
+
+## References
+
+- [AGENTS.md Standard Website](https://agents.md/)
+- [GitHub Copilot AGENTS.md Support Announcement](https://github.blog/changelog/2025-08-28-copilot-coding-agent-now-supports-agents-md-custom-instructions/)
+- [GitHub Documentation: Repository Custom Instructions](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions)
+- [Issue #172: Start using agents.md](https://github.com/torrust/torrust-tracker-deployer/issues/172)
+- [OpenAI agents.md Repository](https://github.com/openai/agents.md)
+
+## Implementation Notes
+
+**Date implemented:** 2025-11-13
+
+**Files changed:**
+
+- Created: `AGENTS.md` (repository root)
+- Modified: `.github/copilot-instructions.md` (now redirect)
+- Modified: `project-words.txt` (added "AGENTS")
+- Created: `docs/decisions/agents-md-migration.md` (this ADR)
+
+**Testing:**
+
+- Verify GitHub Copilot can read `AGENTS.md`
+- Verify redirect message is clear in `.github/copilot-instructions.md`
+- Confirm spell-check passes with new term

--- a/project-words.txt
+++ b/project-words.txt
@@ -1,4 +1,5 @@
 AAAAB
+AGENTS
 addgroup
 adduser
 appender


### PR DESCRIPTION
## Overview

Migrates from GitHub-specific `.github/copilot-instructions.md` to the open `AGENTS.md` standard, enabling compatibility with multiple AI coding agents while maintaining backward compatibility.

## Changes

- ✅ Created `AGENTS.md` at repository root with complete AI agent instructions
- ✅ Updated `.github/copilot-instructions.md` to serve as a redirect/notice file
- ✅ Added "AGENTS" to project spell-check dictionary
- ✅ Documented decision in ADR: `docs/decisions/agents-md-migration.md`
- ✅ Updated ADR index with new decision record

## Benefits

- **Multi-agent compatibility**: Works with GitHub Copilot, Cursor, Aider, Jules, and other agents
- **Industry standard**: Adopts community-maintained open format (https://agents.md/)
- **Backward compatible**: GitHub Copilot users can still find instructions via redirect
- **Future-proof**: Not locked into vendor-specific format

## Technical Details

The `AGENTS.md` standard is officially supported by GitHub Copilot as of August 28, 2025. The redirect file ensures no breaking changes for existing users while we adopt the more flexible standard.

## Related

Closes #172

## Testing

- [x] All linters pass
- [x] Markdown formatting validated
- [x] Spell check passes with new term
- [x] ADR properly documented