### PR TITLE
refactor: [#176] Convert presentation layer to async

### DIFF
--- a/src/bootstrap/app.rs
+++ b/src/bootstrap/app.rs
@@ -40,7 +40,7 @@ use crate::{bootstrap, presentation};
 /// - Logging initialization fails (usually means it was already initialized)
 ///
 /// Both panics are intentional as logging is critical for observability.
-pub fn run() {
+pub async fn run() {
     let cli = presentation::Cli::parse();
 
     let logging_config = cli.global.logging_config();
@@ -67,6 +67,7 @@ pub fn run() {
         Some(command) => {
             if let Err(e) =
                 presentation::dispatch::route_command(command, &cli.global.working_dir, &context)
+                    .await
             {
                 presentation::error::handle_error(&e, &context.user_output());
                 std::process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 
 use torrust_tracker_deployer_lib::bootstrap;
 
-fn main() {
-    bootstrap::app::run();
+#[tokio::main]
+async fn main() {
+    bootstrap::app::run().await;
 }

--- a/src/presentation/controllers/create/mod.rs
+++ b/src/presentation/controllers/create/mod.rs
@@ -27,16 +27,19 @@
 //! use torrust_tracker_deployer_lib::presentation::controllers::create;
 //! use torrust_tracker_deployer_lib::presentation::dispatch::ExecutionContext;
 //!
+//! # #[tokio::main]
+//! # async fn main() {
 //! let action = CreateAction::Environment {
 //!     env_file: PathBuf::from("config/environment.json")
 //! };
 //! // Note: ExecutionContext would be provided by the application bootstrap
 //! # let context = todo!(); // Mock for documentation example
 //!
-//! if let Err(e) = create::route_command(action, Path::new("."), &context) {
+//! if let Err(e) = create::route_command(action, Path::new("."), &context).await {
 //!     eprintln!("Create failed: {e}");
 //!     eprintln!("\n{}", e.help());
 //! }
+//! # }
 //! ```
 
 pub mod errors;

--- a/src/presentation/controllers/create/router.rs
+++ b/src/presentation/controllers/create/router.rs
@@ -28,7 +28,7 @@ use super::{errors::CreateCommandError, subcommands};
 ///
 /// Returns an error if the subcommand execution fails.
 #[allow(clippy::result_large_err)] // Error contains detailed context for user guidance
-pub fn route_command(
+pub async fn route_command(
     action: CreateAction,
     working_dir: &Path,
     context: &ExecutionContext,
@@ -36,12 +36,14 @@ pub fn route_command(
     match action {
         CreateAction::Environment { env_file } => {
             subcommands::handle(&env_file, working_dir, context)
+                .await
                 .map(|_| ()) // Convert Environment<Created> to ()
                 .map_err(CreateCommandError::Environment)
         }
         CreateAction::Template { output_path } => {
             let template_path = output_path.unwrap_or_else(CreateAction::default_template_path);
             subcommands::handle_template_creation(&template_path, context)
+                .await
                 .map_err(CreateCommandError::Template)
         }
     }

--- a/src/presentation/controllers/create/subcommands/environment/handler.rs
+++ b/src/presentation/controllers/create/subcommands/environment/handler.rs
@@ -74,12 +74,12 @@ const ENVIRONMENT_CREATION_WORKFLOW_STEPS: usize = 3;
 /// let env_file = Path::new("./environment.json");
 /// let working_dir = Path::new("./");
 ///
-/// environment::handle(env_file, working_dir, &context)?;
+/// environment::handle(env_file, working_dir, &context).await?;
 /// # Ok(())
 /// # }
 /// ```
 #[allow(clippy::result_large_err)] // Error contains detailed context for user guidance
-pub fn handle(
+pub async fn handle(
     env_file: &Path,
     working_dir: &Path,
     context: &crate::presentation::dispatch::context::ExecutionContext,
@@ -91,6 +91,7 @@ pub fn handle(
         &context.clock(),
         &context.user_output(),
     )
+    .await
 }
 
 // ============================================================================
@@ -135,6 +136,8 @@ pub fn handle(
 /// use torrust_tracker_deployer_lib::presentation::controllers::create::subcommands::environment;
 /// use torrust_tracker_deployer_lib::presentation::views::VerbosityLevel;
 ///
+/// # #[tokio::main]
+/// # async fn main() {
 /// let container = Container::new(VerbosityLevel::Normal);
 /// let context = ExecutionContext::new(Arc::new(container));
 ///
@@ -142,10 +145,11 @@ pub fn handle(
 ///     Path::new("config.json"),
 ///     Path::new("./"),
 ///     &context
-/// ) {
+/// ).await {
 ///     eprintln!("Environment creation failed: {e}");
 ///     eprintln!("Help: {}", e.help());
 /// }
+/// # }
 /// ```
 ///
 /// Direct usage (for testing or specialized scenarios):
@@ -158,6 +162,8 @@ pub fn handle(
 /// use torrust_tracker_deployer_lib::bootstrap::Container;
 /// use torrust_tracker_deployer_lib::presentation::views::VerbosityLevel;
 ///
+/// # #[tokio::main]
+/// # async fn main() {
 /// let container = Arc::new(Container::new(VerbosityLevel::Normal));
 /// let context = ExecutionContext::new(container);
 ///
@@ -165,13 +171,14 @@ pub fn handle(
 ///     Path::new("config.json"),
 ///     Path::new("./"),
 ///     &context
-/// ) {
+/// ).await {
 ///     eprintln!("Environment creation failed: {e}");
 ///     eprintln!("Help: {}", e.help());
 /// }
+/// # }
 /// ```
 #[allow(clippy::result_large_err)] // Error contains detailed context for user guidance
-pub fn handle_environment_creation_command(
+pub async fn handle_environment_creation_command(
     env_file: &Path,
     working_dir: &Path,
     repository_factory: &Arc<RepositoryFactory>,
@@ -180,6 +187,7 @@ pub fn handle_environment_creation_command(
 ) -> Result<Environment<Created>, CreateEnvironmentCommandError> {
     CreateEnvironmentCommandController::new(repository_factory.clone(), clock.clone(), user_output)
         .execute(env_file, working_dir)
+        .await
 }
 
 // ============================================================================
@@ -255,7 +263,8 @@ impl CreateEnvironmentCommandController {
     ///
     /// Returns `Ok(Environment<Created>)` on success, or a `CreateEnvironmentCommandError` if any step fails.
     #[allow(clippy::result_large_err)]
-    pub fn execute(
+    #[allow(clippy::unused_async)] // Part of uniform async presentation layer interface
+    pub async fn execute(
         &mut self,
         env_file: &Path,
         working_dir: &Path,

--- a/src/presentation/controllers/create/subcommands/environment/tests.rs
+++ b/src/presentation/controllers/create/subcommands/environment/tests.rs
@@ -19,8 +19,8 @@ fn create_test_context() -> ExecutionContext {
     ExecutionContext::new(Arc::new(container))
 }
 
-#[test]
-fn it_should_create_environment_from_valid_config() {
+#[tokio::test]
+async fn it_should_create_environment_from_valid_config() {
     let temp_dir = TempDir::new().unwrap();
     let config_path = temp_dir.path().join("config.json");
 
@@ -45,7 +45,7 @@ fn it_should_create_environment_from_valid_config() {
 
     let working_dir = temp_dir.path();
     let context = create_test_context();
-    let result = handle(&config_path, working_dir, &context);
+    let result = handle(&config_path, working_dir, &context).await;
 
     assert!(
         result.is_ok(),
@@ -63,14 +63,14 @@ fn it_should_create_environment_from_valid_config() {
     );
 }
 
-#[test]
-fn it_should_return_error_for_missing_config_file() {
+#[tokio::test]
+async fn it_should_return_error_for_missing_config_file() {
     let temp_dir = TempDir::new().unwrap();
     let config_path = temp_dir.path().join("nonexistent.json");
     let working_dir = temp_dir.path();
     let context = create_test_context();
 
-    let result = handle(&config_path, working_dir, &context);
+    let result = handle(&config_path, working_dir, &context).await;
 
     assert!(result.is_err());
     match result.unwrap_err() {
@@ -81,8 +81,8 @@ fn it_should_return_error_for_missing_config_file() {
     }
 }
 
-#[test]
-fn it_should_return_error_for_invalid_json() {
+#[tokio::test]
+async fn it_should_return_error_for_invalid_json() {
     let temp_dir = TempDir::new().unwrap();
     let config_path = temp_dir.path().join("invalid.json");
 
@@ -91,7 +91,7 @@ fn it_should_return_error_for_invalid_json() {
 
     let working_dir = temp_dir.path();
     let context = create_test_context();
-    let result = handle(&config_path, working_dir, &context);
+    let result = handle(&config_path, working_dir, &context).await;
 
     assert!(result.is_err());
     match result.unwrap_err() {
@@ -102,8 +102,8 @@ fn it_should_return_error_for_invalid_json() {
     }
 }
 
-#[test]
-fn it_should_return_error_for_duplicate_environment() {
+#[tokio::test]
+async fn it_should_return_error_for_duplicate_environment() {
     let temp_dir = TempDir::new().unwrap();
     let config_path = temp_dir.path().join("config.json");
 
@@ -129,12 +129,12 @@ fn it_should_return_error_for_duplicate_environment() {
     let context = create_test_context();
 
     // Create environment first time
-    let result1 = handle(&config_path, working_dir, &context);
+    let result1 = handle(&config_path, working_dir, &context).await;
     assert!(result1.is_ok(), "First create should succeed");
 
     // Try to create same environment again (use new context to avoid any state issues)
     let context2 = create_test_context();
-    let result2 = handle(&config_path, working_dir, &context2);
+    let result2 = handle(&config_path, working_dir, &context2).await;
     assert!(result2.is_err(), "Second create should fail");
 
     match result2.unwrap_err() {
@@ -145,8 +145,8 @@ fn it_should_return_error_for_duplicate_environment() {
     }
 }
 
-#[test]
-fn it_should_create_environment_in_custom_working_dir() {
+#[tokio::test]
+async fn it_should_create_environment_in_custom_working_dir() {
     let temp_dir = TempDir::new().unwrap();
     let custom_working_dir = temp_dir.path().join("custom");
     fs::create_dir(&custom_working_dir).unwrap();
@@ -172,7 +172,7 @@ fn it_should_create_environment_in_custom_working_dir() {
     fs::write(&config_path, config_json).unwrap();
 
     let context = create_test_context();
-    let result = handle(&config_path, &custom_working_dir, &context);
+    let result = handle(&config_path, &custom_working_dir, &context).await;
 
     assert!(result.is_ok(), "Should create in custom working dir");
 

--- a/src/presentation/controllers/create/tests/template.rs
+++ b/src/presentation/controllers/create/tests/template.rs
@@ -10,8 +10,8 @@ use crate::presentation::dispatch::ExecutionContext;
 use crate::presentation::input::cli::CreateAction;
 use crate::presentation::views::VerbosityLevel;
 
-#[test]
-fn it_should_generate_template_with_default_path() {
+#[tokio::test]
+async fn it_should_generate_template_with_default_path() {
     let test_context = TestContext::new();
 
     // Change to temp directory so template is created there
@@ -22,7 +22,7 @@ fn it_should_generate_template_with_default_path() {
     let container = Container::new(VerbosityLevel::Silent);
     let context = ExecutionContext::new(std::sync::Arc::new(container));
 
-    let result = create::route_command(action, test_context.working_dir(), &context);
+    let result = create::route_command(action, test_context.working_dir(), &context).await;
 
     // Restore original directory
     std::env::set_current_dir(original_dir).unwrap();
@@ -53,8 +53,8 @@ fn it_should_generate_template_with_default_path() {
     assert_eq!(parsed["ssh_credentials"]["port"], 22);
 }
 
-#[test]
-fn it_should_generate_template_with_custom_path() {
+#[tokio::test]
+async fn it_should_generate_template_with_custom_path() {
     let test_context = TestContext::new();
     let custom_path = test_context
         .working_dir()
@@ -67,7 +67,7 @@ fn it_should_generate_template_with_custom_path() {
     let container = Container::new(VerbosityLevel::Silent);
     let context = ExecutionContext::new(std::sync::Arc::new(container));
 
-    let result = create::route_command(action, test_context.working_dir(), &context);
+    let result = create::route_command(action, test_context.working_dir(), &context).await;
 
     assert!(result.is_ok(), "Template generation should succeed");
 
@@ -82,8 +82,8 @@ fn it_should_generate_template_with_custom_path() {
     assert!(custom_path.parent().unwrap().exists());
 }
 
-#[test]
-fn it_should_generate_valid_json_template() {
+#[tokio::test]
+async fn it_should_generate_valid_json_template() {
     let test_context = TestContext::new();
     let template_path = test_context.working_dir().join("test.json");
 
@@ -93,7 +93,9 @@ fn it_should_generate_valid_json_template() {
     let container = Container::new(VerbosityLevel::Silent);
     let context = ExecutionContext::new(std::sync::Arc::new(container));
 
-    create::route_command(action, test_context.working_dir(), &context).unwrap();
+    create::route_command(action, test_context.working_dir(), &context)
+        .await
+        .unwrap();
 
     // Read and parse the generated template
     let file_content = std::fs::read_to_string(&template_path).unwrap();
@@ -123,8 +125,8 @@ fn it_should_generate_valid_json_template() {
     assert_eq!(parsed["ssh_credentials"]["port"], 22);
 }
 
-#[test]
-fn it_should_create_parent_directories() {
+#[tokio::test]
+async fn it_should_create_parent_directories() {
     let test_context = TestContext::new();
     let deep_path = test_context
         .working_dir()
@@ -139,7 +141,7 @@ fn it_should_create_parent_directories() {
     let container = Container::new(VerbosityLevel::Silent);
     let context = ExecutionContext::new(std::sync::Arc::new(container));
 
-    let result = create::route_command(action, test_context.working_dir(), &context);
+    let result = create::route_command(action, test_context.working_dir(), &context).await;
 
     assert!(result.is_ok(), "Should create parent directories");
     assert!(

--- a/src/presentation/controllers/destroy/errors.rs
+++ b/src/presentation/controllers/destroy/errors.rs
@@ -109,13 +109,16 @@ impl DestroySubcommandError {
     /// use torrust_tracker_deployer_lib::presentation::controllers::destroy;
     /// use torrust_tracker_deployer_lib::presentation::views::VerbosityLevel;
     ///
+    /// # #[tokio::main]
+    /// # async fn main() {
     /// let container = Container::new(VerbosityLevel::Normal);
     /// let context = ExecutionContext::new(Arc::new(container));
     ///
-    /// if let Err(e) = destroy::handle("test-env", Path::new("."), &context) {
+    /// if let Err(e) = destroy::handle("test-env", Path::new("."), &context).await {
     ///     eprintln!("Error: {e}");
     ///     eprintln!("\nTroubleshooting:\n{}", e.help());
     /// }
+    /// # }
     /// ```
     ///
     /// Direct usage (for testing):
@@ -131,13 +134,16 @@ impl DestroySubcommandError {
     /// use torrust_tracker_deployer_lib::infrastructure::persistence::repository_factory::RepositoryFactory;
     /// use torrust_tracker_deployer_lib::shared::clock::SystemClock;
     ///
+    /// # #[tokio::main]
+    /// # async fn main() {
     /// let output = Arc::new(ReentrantMutex::new(RefCell::new(UserOutput::new(VerbosityLevel::Normal))));
     /// let repository_factory = Arc::new(RepositoryFactory::new(Duration::from_secs(30)));
     /// let clock = Arc::new(SystemClock);
-    /// if let Err(e) = destroy::handle_destroy_command("test-env", Path::new("."), repository_factory, clock, &output) {
+    /// if let Err(e) = destroy::handle_destroy_command("test-env", Path::new("."), repository_factory, clock, &output).await {
     ///     eprintln!("Error: {e}");
     ///     eprintln!("\nTroubleshooting:\n{}", e.help());
     /// }
+    /// # }
     /// ```
     #[must_use]
     #[allow(clippy::too_many_lines)] // Help text is comprehensive for user guidance

--- a/src/presentation/controllers/destroy/mod.rs
+++ b/src/presentation/controllers/destroy/mod.rs
@@ -43,13 +43,16 @@
 //! use torrust_tracker_deployer_lib::presentation::controllers::destroy;
 //! use torrust_tracker_deployer_lib::presentation::views::VerbosityLevel;
 //!
+//! # #[tokio::main]
+//! # async fn main() {
 //! let container = Container::new(VerbosityLevel::Normal);
 //! let context = ExecutionContext::new(Arc::new(container));
 //!
-//! if let Err(e) = destroy::handle("test-env", Path::new("."), &context) {
+//! if let Err(e) = destroy::handle("test-env", Path::new("."), &context).await {
 //!     eprintln!("Destroy failed: {e}");
 //!     eprintln!("\n{}", e.help());
 //! }
+//! # }
 //! ```
 //!
 //! ## Direct Usage (For Testing)
@@ -65,13 +68,16 @@
 //! use torrust_tracker_deployer_lib::infrastructure::persistence::repository_factory::RepositoryFactory;
 //! use torrust_tracker_deployer_lib::shared::clock::SystemClock;
 //!
+//! # #[tokio::main]
+//! # async fn main() {
 //! let output = Arc::new(ReentrantMutex::new(RefCell::new(UserOutput::new(VerbosityLevel::Normal))));
 //! let repository_factory = Arc::new(RepositoryFactory::new(Duration::from_secs(30)));
 //! let clock = Arc::new(SystemClock);
-//! if let Err(e) = destroy::handle_destroy_command("test-env", Path::new("."), repository_factory, clock, &output) {
+//! if let Err(e) = destroy::handle_destroy_command("test-env", Path::new("."), repository_factory, clock, &output).await {
 //!     eprintln!("Destroy failed: {e}");
 //!     eprintln!("\n{}", e.help());
 //! }
+//! # }
 //! ```
 
 pub mod errors;

--- a/src/presentation/controllers/destroy/tests/integration.rs
+++ b/src/presentation/controllers/destroy/tests/integration.rs
@@ -14,8 +14,8 @@ use crate::presentation::views::testing::TestUserOutput;
 use crate::presentation::views::VerbosityLevel;
 use crate::shared::SystemClock;
 
-#[test]
-fn it_should_reject_invalid_environment_names() {
+#[tokio::test]
+async fn it_should_reject_invalid_environment_names() {
     let context = TestContext::new();
 
     let invalid_names = vec![
@@ -36,7 +36,8 @@ fn it_should_reject_invalid_environment_names() {
             repository_factory,
             clock,
             &user_output,
-        );
+        )
+        .await;
         assert!(
             result.is_err(),
             "Should reject invalid environment name: {name}",
@@ -61,14 +62,15 @@ fn it_should_reject_invalid_environment_names() {
         repository_factory,
         clock,
         &user_output,
-    );
+    )
+    .await;
     assert!(result.is_err(), "Should get some error for 64-char name");
     // Accept either InvalidEnvironmentName OR DestroyOperationFailed
     // The domain layer determines what length is valid
 }
 
-#[test]
-fn it_should_accept_valid_environment_names() {
+#[tokio::test]
+async fn it_should_accept_valid_environment_names() {
     let context = TestContext::new();
 
     let valid_names = vec![
@@ -90,7 +92,8 @@ fn it_should_accept_valid_environment_names() {
             repository_factory,
             clock,
             &user_output,
-        );
+        )
+        .await;
 
         // Will fail at operation since environment doesn't exist,
         // but should NOT fail at name validation
@@ -111,15 +114,16 @@ fn it_should_accept_valid_environment_names() {
         repository_factory,
         clock,
         &user_output,
-    );
+    )
+    .await;
     if let Err(DestroySubcommandError::InvalidEnvironmentName { .. }) = result {
         panic!("Should not reject valid 63-char environment name");
     }
     // Expected - valid name but operation fails or other errors acceptable in test context
 }
 
-#[test]
-fn it_should_fail_for_nonexistent_environment() {
+#[tokio::test]
+async fn it_should_fail_for_nonexistent_environment() {
     let context = TestContext::new();
     let (user_output, _, _) = TestUserOutput::new(VerbosityLevel::Normal).into_reentrant_wrapped();
     let repository_factory = Arc::new(RepositoryFactory::new(DEFAULT_LOCK_TIMEOUT));
@@ -131,7 +135,8 @@ fn it_should_fail_for_nonexistent_environment() {
         repository_factory,
         clock,
         &user_output,
-    );
+    )
+    .await;
 
     assert!(result.is_err());
     match result.unwrap_err() {
@@ -142,8 +147,8 @@ fn it_should_fail_for_nonexistent_environment() {
     }
 }
 
-#[test]
-fn it_should_provide_help_for_errors() {
+#[tokio::test]
+async fn it_should_provide_help_for_errors() {
     let context = TestContext::new();
     let repository_factory = Arc::new(RepositoryFactory::new(DEFAULT_LOCK_TIMEOUT));
     let clock = Arc::new(SystemClock);
@@ -154,7 +159,8 @@ fn it_should_provide_help_for_errors() {
         repository_factory,
         clock,
         &context.user_output(),
-    );
+    )
+    .await;
 
     assert!(result.is_err());
     let error = result.unwrap_err();
@@ -167,8 +173,8 @@ fn it_should_provide_help_for_errors() {
     );
 }
 
-#[test]
-fn it_should_work_with_custom_working_directory() {
+#[tokio::test]
+async fn it_should_work_with_custom_working_directory() {
     let context = TestContext::new();
     let custom_working_dir = context.working_dir().join("custom");
     fs::create_dir(&custom_working_dir).unwrap();
@@ -183,7 +189,8 @@ fn it_should_work_with_custom_working_directory() {
         repository_factory,
         clock,
         &context.user_output(),
-    );
+    )
+    .await;
 
     // Should fail at operation (environment doesn't exist) but not at path validation
     assert!(result.is_err());

--- a/src/presentation/controllers/mod.rs
+++ b/src/presentation/controllers/mod.rs
@@ -135,7 +135,12 @@
 //! use torrust_tracker_deployer_lib::presentation::controllers::create::errors::CreateCommandError;
 //! use torrust_tracker_deployer_lib::presentation::controllers::create::subcommands;
 //!
-//! pub fn route_command(
+//! # #[tokio::main]
+//! # async fn main() {
+//! # let action = todo!();
+//! # let working_dir = todo!();
+//! # let context = todo!();
+//! pub async fn route_command(
 //!     action: CreateAction,
 //!     working_dir: &Path,
 //!     context: &ExecutionContext,
@@ -143,16 +148,19 @@
 //!     match action {
 //!         CreateAction::Environment { env_file } => {
 //!             subcommands::environment::handle(&env_file, working_dir, context)
+//!                 .await
 //!                 .map(|_| ()) // Convert Environment<Created> to ()
 //!                 .map_err(CreateCommandError::Environment)
 //!         }
 //!         CreateAction::Template { output_path } => {
 //!             let template_path = output_path.unwrap_or_else(CreateAction::default_template_path);
 //!             subcommands::template::handle(&template_path, context)
+//!                 .await
 //!                 .map_err(CreateCommandError::Template)
 //!         }
 //!     }
 //! }
+//! # }
 //! ```
 //!
 //! **Target Architecture**: Move routing to dispatch layer, make each subcommand

--- a/src/presentation/controllers/provision/errors.rs
+++ b/src/presentation/controllers/provision/errors.rs
@@ -119,13 +119,16 @@ impl ProvisionSubcommandError {
     /// use torrust_tracker_deployer_lib::presentation::controllers::provision;
     /// use torrust_tracker_deployer_lib::presentation::views::VerbosityLevel;
     ///
+    /// # #[tokio::main]
+    /// # async fn main() {
     /// let container = Container::new(VerbosityLevel::Normal);
     /// let context = ExecutionContext::new(Arc::new(container));
     ///
-    /// if let Err(e) = provision::handle("test-env", Path::new("."), &context) {
+    /// if let Err(e) = provision::handle("test-env", Path::new("."), &context).await {
     ///     eprintln!("Error: {e}");
     ///     eprintln!("\nTroubleshooting:\n{}", e.help());
     /// }
+    /// # }
     /// ```
     ///
     /// Direct usage (for testing):
@@ -141,13 +144,16 @@ impl ProvisionSubcommandError {
     /// use torrust_tracker_deployer_lib::infrastructure::persistence::repository_factory::RepositoryFactory;
     /// use torrust_tracker_deployer_lib::shared::clock::SystemClock;
     ///
+    /// # #[tokio::main]
+    /// # async fn main() {
     /// let output = Arc::new(ReentrantMutex::new(RefCell::new(UserOutput::new(VerbosityLevel::Normal))));
     /// let repository_factory = Arc::new(RepositoryFactory::new(Duration::from_secs(30)));
     /// let clock = Arc::new(SystemClock);
-    /// if let Err(e) = provision::handle_provision_command("test-env", Path::new("."), repository_factory, clock, &output) {
+    /// if let Err(e) = provision::handle_provision_command("test-env", Path::new("."), repository_factory, clock, &output).await {
     ///     eprintln!("Error: {e}");
     ///     eprintln!("\nTroubleshooting:\n{}", e.help());
     /// }
+    /// # }
     /// ```
     #[must_use]
     #[allow(clippy::too_many_lines)] // Help text is comprehensive for user guidance

--- a/src/presentation/controllers/provision/mod.rs
+++ b/src/presentation/controllers/provision/mod.rs
@@ -43,13 +43,16 @@
 //! use torrust_tracker_deployer_lib::presentation::controllers::provision;
 //! use torrust_tracker_deployer_lib::presentation::views::VerbosityLevel;
 //!
+//! # #[tokio::main]
+//! # async fn main() {
 //! let container = Container::new(VerbosityLevel::Normal);
 //! let context = ExecutionContext::new(Arc::new(container));
 //!
-//! if let Err(e) = provision::handle("test-env", Path::new("."), &context) {
+//! if let Err(e) = provision::handle("test-env", Path::new("."), &context).await {
 //!     eprintln!("Provision failed: {e}");
 //!     eprintln!("\n{}", e.help());
 //! }
+//! # }
 //! ```
 //!
 //! ## Direct Usage (For Testing)
@@ -65,13 +68,16 @@
 //! use torrust_tracker_deployer_lib::infrastructure::persistence::repository_factory::RepositoryFactory;
 //! use torrust_tracker_deployer_lib::shared::clock::SystemClock;
 //!
+//! # #[tokio::main]
+//! # async fn main() {
 //! let output = Arc::new(ReentrantMutex::new(RefCell::new(UserOutput::new(VerbosityLevel::Normal))));
 //! let repository_factory = Arc::new(RepositoryFactory::new(Duration::from_secs(30)));
 //! let clock = Arc::new(SystemClock);
-//! if let Err(e) = provision::handle_provision_command("test-env", Path::new("."), repository_factory, clock, &output) {
+//! if let Err(e) = provision::handle_provision_command("test-env", Path::new("."), repository_factory, clock, &output).await {
 //!     eprintln!("Provision failed: {e}");
 //!     eprintln!("\n{}", e.help());
 //! }
+//! # }
 //! ```
 
 pub mod errors;

--- a/src/presentation/dispatch/router.rs
+++ b/src/presentation/dispatch/router.rs
@@ -93,42 +93,42 @@ use super::ExecutionContext;
 /// use torrust_tracker_deployer_lib::presentation::views::VerbosityLevel;
 /// // Note: Commands enum requires specific action parameters in practice
 ///
-/// fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// async fn example() -> Result<(), Box<dyn std::error::Error>> {
 ///     let container = Container::new(VerbosityLevel::Normal);
 ///     let context = ExecutionContext::new(Arc::new(container));
 ///     let working_dir = Path::new(".");
 ///
 ///     // Route command to appropriate handler - requires proper Commands construction
-///     // route_command(command, working_dir, &context)?;
+///     // route_command(command, working_dir, &context).await?;
 ///     Ok(())
 /// }
 /// ```
-pub fn route_command(
+pub async fn route_command(
     command: Commands,
     working_dir: &Path,
     context: &ExecutionContext,
 ) -> Result<(), CommandError> {
     match command {
         Commands::Create { action } => {
-            create::route_command(action, working_dir, context)?;
+            create::route_command(action, working_dir, context).await?;
             Ok(())
         }
         Commands::Destroy { environment } => {
-            destroy::handle(&environment, working_dir, context)?;
+            destroy::handle(&environment, working_dir, context).await?;
             Ok(())
         }
         Commands::Provision { environment } => {
-            provision::handle(&environment, working_dir, context)?;
+            provision::handle(&environment, working_dir, context).await?;
             Ok(())
         } // Future commands will be added here as the Controller Layer expands:
           //
           // Commands::Configure { environment } => {
-          //     configure::handle_configure_command(&environment, context)?;
+          //     configure::handle_configure_command(&environment, context).await?;
           //     Ok(())
           // }
           //
           // Commands::Release { environment, version } => {
-          //     release::handle_release_command(&environment, &version, context)?;
+          //     release::handle_release_command(&environment, &version, context).await?;
           //     Ok(())
           // }
     }


### PR DESCRIPTION
## Summary

This PR completes the conversion of the presentation layer to async/await patterns, addressing issue #176.

## Changes

### Core Async Conversion
- ✅ **main.rs**: Converted to async entry point with `#[tokio::main]`
- ✅ **bootstrap/app.rs**: Made `run()` function async
- ✅ **dispatch/router.rs**: Converted router to handle async controllers

### Controller Updates
- ✅ **provision**: Converted handler and all functions to async
- ✅ **destroy**: Converted handler and all functions to async  
- ✅ **create**: Converted router and all subcommand handlers to async
  - environment subcommand
  - template subcommand

### Test Updates
- ✅ Converted all unit tests to use `#[tokio::test]`
- ✅ Added `.await` to all async function calls in tests
- ✅ Updated helper functions to be async where needed

### Code Quality
- ✅ Added `#[allow(clippy::unused_async)]` to controller `execute()` methods that maintain async interface uniformity
- ✅ Updated all documentation examples with async wrappers (`#[tokio::main]`)
- ✅ All pre-commit checks pass

## Benefits

1. **Cleaner Code**: Removed manual `Runtime::new()` patterns from provision controller
2. **Consistency**: Uniform async interface throughout presentation layer
3. **Future-Ready**: Prepared for async I/O operations in controllers
4. **Better Testing**: All tests use proper async test framework

## Testing

- [x] All unit tests pass
- [x] Code compiles without errors
- [x] Pre-commit checks pass (cargo machete, linting, formatting, doctests)
- [x] Documentation examples compile

## Related Issue

Closes #176