### PR TITLE
fix: [#181] use ansible_user variable instead of hardcoded username

### DIFF
--- a/src/application/steps/rendering/ansible_templates.rs
+++ b/src/application/steps/rendering/ansible_templates.rs
@@ -146,11 +146,13 @@ impl RenderAnsibleTemplatesStep {
         let host = AnsibleHost::from(self.ssh_socket_addr.ip());
         let ssh_key = SshPrivateKeyFile::new(&self.ssh_credentials.ssh_priv_key_path)?;
         let ssh_port = AnsiblePort::new(self.ssh_socket_addr.port())?;
+        let ansible_user = self.ssh_credentials.ssh_username.as_str().to_string();
 
         InventoryContext::builder()
             .with_host(host)
             .with_ssh_priv_key_path(ssh_key)
             .with_ssh_port(ssh_port)
+            .with_ansible_user(ansible_user)
             .build()
             .map_err(RenderAnsibleTemplatesError::from)
     }

--- a/src/infrastructure/external_tools/ansible/template/renderer/inventory.rs
+++ b/src/infrastructure/external_tools/ansible/template/renderer/inventory.rs
@@ -219,6 +219,7 @@ mod tests {
             .with_host(host)
             .with_ssh_priv_key_path(ssh_key)
             .with_ssh_port(ssh_port)
+            .with_ansible_user("torrust".to_string())
             .build()
             .expect("Failed to build inventory context")
     }
@@ -233,7 +234,7 @@ mod tests {
     torrust-tracker-vm:
       ansible_host: {{ ansible_host }}
       ansible_port: {{ ansible_port }}
-      ansible_user: torrust
+      ansible_user: {{ ansible_user }}
       ansible_connection: ssh
       ansible_ssh_private_key_file: {{ ansible_ssh_private_key_file }}
       ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
@@ -304,7 +305,7 @@ mod tests {
         );
         assert!(
             output_content.contains("ansible_user: torrust"),
-            "Output should contain ansible_user: {output_content}"
+            "Output should contain ansible_user with correct value: {output_content}"
         );
     }
 
@@ -323,7 +324,7 @@ mod tests {
   hosts:
     torrust-tracker-vm:
       ansible_host: {{ ansible_host }}
-      ansible_user: torrust
+      ansible_user: {{ ansible_user }}
       missing_field: {{ non_existent_field }}
 ";
 

--- a/src/infrastructure/external_tools/ansible/template/renderer/mod.rs
+++ b/src/infrastructure/external_tools/ansible/template/renderer/mod.rs
@@ -37,6 +37,7 @@
 //!     .with_host(host)
 //!     .with_ssh_priv_key_path(ssh_key)
 //!     .with_ssh_port(ssh_port)
+//!     .with_ansible_user("torrust".to_string())
 //!     .build()?;
 //!
 //! // Note: This would require actual template files to work
@@ -437,7 +438,7 @@ impl AnsibleTemplateRenderer {
 mod tests {
     use super::*;
     use crate::infrastructure::external_tools::ansible::template::wrappers::inventory::{
-        AnsibleHost, InventoryContext, SshPrivateKeyFile,
+        AnsibleHost, AnsiblePort, InventoryContext, SshPrivateKeyFile,
     };
     use std::str::FromStr;
     use tempfile::TempDir;
@@ -447,10 +448,13 @@ mod tests {
     fn create_test_inventory_context() -> InventoryContext {
         let host = AnsibleHost::from_str("192.168.1.100").expect("Valid IP address");
         let ssh_key = SshPrivateKeyFile::new("/path/to/ssh/key").expect("Valid SSH key path");
+        let ssh_port = AnsiblePort::new(22).expect("Valid SSH port");
 
         InventoryContext::builder()
             .with_host(host)
             .with_ssh_priv_key_path(ssh_key)
+            .with_ssh_port(ssh_port)
+            .with_ansible_user("torrust".to_string())
             .build()
             .expect("Valid inventory context")
     }

--- a/src/infrastructure/external_tools/ansible/template/wrappers/inventory/mod.rs
+++ b/src/infrastructure/external_tools/ansible/template/wrappers/inventory/mod.rs
@@ -93,6 +93,7 @@ mod tests {
             .with_host(host)
             .with_ssh_priv_key_path(ssh_key)
             .with_ssh_port(ssh_port)
+            .with_ansible_user("torrust".to_string())
             .build()
             .unwrap()
     }

--- a/templates/ansible/inventory.yml.tera
+++ b/templates/ansible/inventory.yml.tera
@@ -70,7 +70,8 @@ all:
       # The username to use when connecting via SSH
       # 🔗 LXD VM: This must match the user created in cloud-init
       # 🔗 CONTAINER: This must match the pre-configured user in the container image
-      ansible_user: torrust
+      # 🔗 CONFIGURED: Set via ssh_credentials.username in environment config
+      ansible_user: {{ansible_user}}
 
       # Connection method - we're using SSH
       ansible_connection: ssh

--- a/tests/template_integration.rs
+++ b/tests/template_integration.rs
@@ -47,6 +47,7 @@ mod integration_tests {
             .with_host(host)
             .with_ssh_priv_key_path(ssh_key)
             .with_ssh_port(ssh_port)
+            .with_ansible_user("torrust".to_string())
             .build()?;
         let inventory = InventoryTemplate::new(&template_file, inventory_context)?;
 
@@ -101,6 +102,7 @@ mod integration_tests {
             .with_host(host)
             .with_ssh_priv_key_path(ssh_key)
             .with_ssh_port(ssh_port)
+            .with_ansible_user("ubuntu".to_string())
             .build()?;
         let result = InventoryTemplate::new(&template_file, inventory_context);
 
@@ -126,6 +128,7 @@ mod integration_tests {
             .with_host(host)
             .with_ssh_priv_key_path(ssh_key)
             .with_ssh_port(ssh_port)
+            .with_ansible_user("admin".to_string())
             .build()?;
         let result = InventoryTemplate::new(&invalid_template_file, inventory_context.clone());
 
@@ -171,6 +174,7 @@ mod integration_tests {
                 .with_host(host)
                 .with_ssh_priv_key_path(ssh_key)
                 .with_ssh_port(ssh_port)
+                .with_ansible_user(format!("user{i}"))
                 .build()?;
             let inventory = InventoryTemplate::new(&template_file, inventory_context)?;
 
@@ -218,6 +222,7 @@ mod integration_tests {
                 .with_host(host)
                 .with_ssh_priv_key_path(ssh_key)
                 .with_ssh_port(ssh_port)
+                .with_ansible_user("testuser".to_string())
                 .build()?;
             let inventory = InventoryTemplate::new(&template_file, inventory_context)?;
 


### PR DESCRIPTION
## Description

Fixes #181 - Removes hardcoded `ansible_user: torrust` from the inventory template and makes it configurable via the environment's SSH credentials.

## Changes

### Template Update
- **`templates/ansible/inventory.yml.tera`**: Changed from hardcoded `ansible_user: torrust` to variable `ansible_user: {{ansible_user}}`

### Data Structure Updates
- **`InventoryContext` struct**: Added `ansible_user: String` field
- **`InventoryContextBuilder`**: Added `with_ansible_user()` builder method
- **Error handling**: Added `MissingAnsibleUser` error variant
- **Accessors**: Added `ansible_user()` method

### Production Code
- **`create_inventory_context()`**: Now extracts username from `ssh_credentials.ssh_username` and passes it to the builder

### Tests
- Updated all unit tests to include ansible_user
- Updated integration tests to use the variable
- Added new test for missing ansible_user validation
- Fixed all test templates to use `{{ansible_user}}` variable

## Verification

✅ All 1150 unit tests pass  
✅ All integration tests pass  
✅ Pre-commit checks pass  
✅ Manual E2E test verified with custom username `testuser123`  
✅ Rendered inventory file correctly shows configurable username

## Impact

Users can now specify custom SSH usernames (ubuntu, admin, etc.) in their environment configuration instead of being forced to use the hardcoded 'torrust' username.

**Before**: SSH connections always used hardcoded username "torrust"  
**After**: SSH connections use the username specified in `ssh_credentials.username` from environment config