### PR TITLE
refactor: [#194] implement repository injection in controllers

### DIFF
--- a/src/application/command_handlers/create/tests/builders.rs
+++ b/src/application/command_handlers/create/tests/builders.rs
@@ -184,7 +184,9 @@ impl CreateCommandHandlerTestBuilder {
     #[allow(clippy::unused_self)] // Builder pattern - self is consumed in build()
     fn create_existing_environment(
         &self,
-        repository: &Arc<dyn crate::domain::environment::repository::EnvironmentRepository>,
+        repository: &Arc<
+            dyn crate::domain::environment::repository::EnvironmentRepository + Send + Sync,
+        >,
         name: &str,
         base_dir: &Path,
     ) {

--- a/src/bootstrap/app.rs
+++ b/src/bootstrap/app.rs
@@ -60,6 +60,7 @@ pub async fn run() {
     // Initialize service container for dependency injection
     let container = Arc::new(bootstrap::Container::new(
         crate::presentation::controllers::constants::DEFAULT_VERBOSITY,
+        &cli.global.working_dir,
     ));
     let context = presentation::dispatch::ExecutionContext::new(container);
 

--- a/src/infrastructure/persistence/repository_factory.rs
+++ b/src/infrastructure/persistence/repository_factory.rs
@@ -86,7 +86,7 @@ impl RepositoryFactory {
     /// let repo = factory.create(PathBuf::from("data/production"));
     /// ```
     #[must_use]
-    pub fn create(&self, data_dir: PathBuf) -> Arc<dyn EnvironmentRepository> {
+    pub fn create(&self, data_dir: PathBuf) -> Arc<dyn EnvironmentRepository + Send + Sync> {
         let repository =
             FileEnvironmentRepository::new(data_dir).with_lock_timeout(self.lock_timeout);
         Arc::new(repository)

--- a/src/presentation/controllers/configure/errors.rs
+++ b/src/presentation/controllers/configure/errors.rs
@@ -121,10 +121,10 @@ impl ConfigureSubcommandError {
     ///
     /// # #[tokio::main]
     /// # async fn main() {
-    /// let container = Container::new(VerbosityLevel::Normal);
+    /// let container = Container::new(VerbosityLevel::Normal, Path::new("."));
     /// let context = ExecutionContext::new(Arc::new(container));
     ///
-    /// if let Err(e) = configure::handle("test-env", Path::new("."), &context).await {
+    /// if let Err(e) = configure::handle("test-env", &context).await {
     ///     eprintln!("Error: {e}");
     ///     eprintln!("\nTroubleshooting:\n{}", e.help());
     /// }
@@ -147,9 +147,11 @@ impl ConfigureSubcommandError {
     /// # #[tokio::main]
     /// # async fn main() {
     /// let output = Arc::new(ReentrantMutex::new(RefCell::new(UserOutput::new(VerbosityLevel::Normal))));
-    /// let repository_factory = Arc::new(RepositoryFactory::new(Duration::from_secs(30)));
+    /// let data_dir = PathBuf::from("./data");
+    /// let repository_factory = RepositoryFactory::new(Duration::from_secs(30));
+    /// let repository = repository_factory.create(data_dir);
     /// let clock = Arc::new(SystemClock);
-    /// if let Err(e) = configure::handle_configure_command("test-env", Path::new("."), repository_factory, clock, &output).await {
+    /// if let Err(e) = configure::handle_configure_command("test-env", repository, clock, &output).await {
     ///     eprintln!("Error: {e}");
     ///     eprintln!("\nTroubleshooting:\n{}", e.help());
     /// }

--- a/src/presentation/controllers/configure/mod.rs
+++ b/src/presentation/controllers/configure/mod.rs
@@ -26,11 +26,11 @@
 //! use torrust_tracker_deployer_lib::presentation::controllers::configure;
 //! use torrust_tracker_deployer_lib::presentation::views::VerbosityLevel;
 //!
-//! let container = Container::new(VerbosityLevel::Normal);
+//! let container = Container::new(VerbosityLevel::Normal, Path::new("."));
 //! let context = ExecutionContext::new(Arc::new(container));
 //!
 //! // Call the configure handler
-//! let result = configure::handler::handle("my-environment", Path::new("."), &context);
+//! let result = configure::handler::handle("my-environment", &context);
 //! ```
 //!
 //! ### Direct Usage (For Testing)
@@ -45,10 +45,10 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() {
-//! let container = Container::new(VerbosityLevel::Normal);
+//! let container = Container::new(VerbosityLevel::Normal, Path::new("."));
 //! let context = ExecutionContext::new(Arc::new(container));
 //!
-//! if let Err(e) = configure::handle("test-env", Path::new("."), &context).await {
+//! if let Err(e) = configure::handle("test-env", &context).await {
 //!     eprintln!("Configure failed: {e}");
 //!     eprintln!("\n{}", e.help());
 //! }
@@ -58,7 +58,7 @@
 //! ## Direct Usage (For Testing)
 //!
 //! ```rust
-//! use std::path::Path;
+//! use std::path::{Path, PathBuf};
 //! use std::sync::Arc;
 //! use std::time::Duration;
 //! use parking_lot::ReentrantMutex;
@@ -71,9 +71,11 @@
 //! # #[tokio::main]
 //! # async fn main() {
 //! let output = Arc::new(ReentrantMutex::new(RefCell::new(UserOutput::new(VerbosityLevel::Normal))));
-//! let repository_factory = Arc::new(RepositoryFactory::new(Duration::from_secs(30)));
+//! let data_dir = PathBuf::from("./data");
+//! let repository_factory = RepositoryFactory::new(Duration::from_secs(30));
+//! let repository = repository_factory.create(data_dir);
 //! let clock = Arc::new(SystemClock);
-//! if let Err(e) = configure::handle_configure_command("test-env", Path::new("."), repository_factory, clock, &output).await {
+//! if let Err(e) = configure::handle_configure_command("test-env", repository, clock, &output).await {
 //!     eprintln!("Configure failed: {e}");
 //!     eprintln!("\n{}", e.help());
 //! }

--- a/src/presentation/controllers/create/subcommands/template/handler.rs
+++ b/src/presentation/controllers/create/subcommands/template/handler.rs
@@ -60,7 +60,7 @@ const TEMPLATE_CREATION_WORKFLOW_STEPS: usize = 2;
 /// use torrust_tracker_deployer_lib::presentation::views::VerbosityLevel;
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let container = Arc::new(Container::new(VerbosityLevel::Normal));
+/// let container = Arc::new(Container::new(VerbosityLevel::Normal, Path::new(".")));
 /// let context = ExecutionContext::new(container);
 /// let output_path = Path::new("./environment-template.json");
 ///
@@ -117,7 +117,7 @@ pub async fn handle(
 ///
 /// # #[tokio::main]
 /// # async fn main() {
-/// let container = Container::new(VerbosityLevel::Normal);
+/// let container = Container::new(VerbosityLevel::Normal, Path::new("."));
 /// let context = ExecutionContext::new(Arc::new(container));
 ///
 /// if let Err(e) = template::handle(Path::new("template.json"), &context).await {

--- a/src/presentation/controllers/create/tests/environment.rs
+++ b/src/presentation/controllers/create/tests/environment.rs
@@ -21,7 +21,7 @@ async fn handle_environment_creation(
     let action = CreateAction::Environment {
         env_file: config_path.to_path_buf(),
     };
-    let container = Container::new(VerbosityLevel::Silent);
+    let container = Container::new(VerbosityLevel::Silent, working_dir);
     let context = ExecutionContext::new(std::sync::Arc::new(container));
     create::route_command(action, working_dir, &context).await
 }

--- a/src/presentation/controllers/create/tests/template.rs
+++ b/src/presentation/controllers/create/tests/template.rs
@@ -19,7 +19,7 @@ async fn it_should_generate_template_with_default_path() {
     std::env::set_current_dir(test_context.working_dir()).unwrap();
 
     let action = CreateAction::Template { output_path: None };
-    let container = Container::new(VerbosityLevel::Silent);
+    let container = Container::new(VerbosityLevel::Silent, test_context.working_dir());
     let context = ExecutionContext::new(std::sync::Arc::new(container));
 
     let result = create::route_command(action, test_context.working_dir(), &context).await;
@@ -64,7 +64,7 @@ async fn it_should_generate_template_with_custom_path() {
     let action = CreateAction::Template {
         output_path: Some(custom_path.clone()),
     };
-    let container = Container::new(VerbosityLevel::Silent);
+    let container = Container::new(VerbosityLevel::Silent, test_context.working_dir());
     let context = ExecutionContext::new(std::sync::Arc::new(container));
 
     let result = create::route_command(action, test_context.working_dir(), &context).await;
@@ -90,7 +90,7 @@ async fn it_should_generate_valid_json_template() {
     let action = CreateAction::Template {
         output_path: Some(template_path.clone()),
     };
-    let container = Container::new(VerbosityLevel::Silent);
+    let container = Container::new(VerbosityLevel::Silent, test_context.working_dir());
     let context = ExecutionContext::new(std::sync::Arc::new(container));
 
     create::route_command(action, test_context.working_dir(), &context)
@@ -138,7 +138,7 @@ async fn it_should_create_parent_directories() {
     let action = CreateAction::Template {
         output_path: Some(deep_path.clone()),
     };
-    let container = Container::new(VerbosityLevel::Silent);
+    let container = Container::new(VerbosityLevel::Silent, test_context.working_dir());
     let context = ExecutionContext::new(std::sync::Arc::new(container));
 
     let result = create::route_command(action, test_context.working_dir(), &context).await;

--- a/src/presentation/controllers/destroy/errors.rs
+++ b/src/presentation/controllers/destroy/errors.rs
@@ -111,10 +111,10 @@ impl DestroySubcommandError {
     ///
     /// # #[tokio::main]
     /// # async fn main() {
-    /// let container = Container::new(VerbosityLevel::Normal);
+    /// let container = Container::new(VerbosityLevel::Normal, Path::new("."));
     /// let context = ExecutionContext::new(Arc::new(container));
     ///
-    /// if let Err(e) = destroy::handle("test-env", Path::new("."), &context).await {
+    /// if let Err(e) = destroy::handle("test-env", &context).await {
     ///     eprintln!("Error: {e}");
     ///     eprintln!("\nTroubleshooting:\n{}", e.help());
     /// }
@@ -124,7 +124,7 @@ impl DestroySubcommandError {
     /// Direct usage (for testing):
     ///
     /// ```rust
-    /// use std::path::Path;
+    /// use std::path::{Path, PathBuf};
     /// use std::sync::Arc;
     /// use std::time::Duration;
     /// use parking_lot::ReentrantMutex;
@@ -137,9 +137,11 @@ impl DestroySubcommandError {
     /// # #[tokio::main]
     /// # async fn main() {
     /// let output = Arc::new(ReentrantMutex::new(RefCell::new(UserOutput::new(VerbosityLevel::Normal))));
-    /// let repository_factory = Arc::new(RepositoryFactory::new(Duration::from_secs(30)));
+    /// let data_dir = PathBuf::from("./data");
+    /// let repository_factory = RepositoryFactory::new(Duration::from_secs(30));
+    /// let repository = repository_factory.create(data_dir);
     /// let clock = Arc::new(SystemClock);
-    /// if let Err(e) = destroy::handle_destroy_command("test-env", Path::new("."), repository_factory, clock, &output).await {
+    /// if let Err(e) = destroy::handle_destroy_command("test-env", repository, clock, &output).await {
     ///     eprintln!("Error: {e}");
     ///     eprintln!("\nTroubleshooting:\n{}", e.help());
     /// }

--- a/src/presentation/controllers/destroy/mod.rs
+++ b/src/presentation/controllers/destroy/mod.rs
@@ -26,11 +26,11 @@
 //! use torrust_tracker_deployer_lib::presentation::controllers::destroy;
 //! use torrust_tracker_deployer_lib::presentation::views::VerbosityLevel;
 //!
-//! let container = Container::new(VerbosityLevel::Normal);
+//! let container = Container::new(VerbosityLevel::Normal, Path::new("."));
 //! let context = ExecutionContext::new(Arc::new(container));
 //!
 //! // Call the destroy handler
-//! let result = destroy::handler::handle("my-environment", Path::new("."), &context);
+//! let result = destroy::handler::handle("my-environment", &context);
 //! ```
 //!
 //! ### Direct Usage (For Testing)
@@ -45,10 +45,10 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() {
-//! let container = Container::new(VerbosityLevel::Normal);
+//! let container = Container::new(VerbosityLevel::Normal, Path::new("."));
 //! let context = ExecutionContext::new(Arc::new(container));
 //!
-//! if let Err(e) = destroy::handle("test-env", Path::new("."), &context).await {
+//! if let Err(e) = destroy::handle("test-env", &context).await {
 //!     eprintln!("Destroy failed: {e}");
 //!     eprintln!("\n{}", e.help());
 //! }
@@ -58,7 +58,7 @@
 //! ## Direct Usage (For Testing)
 //!
 //! ```rust
-//! use std::path::Path;
+//! use std::path::{Path, PathBuf};
 //! use std::sync::Arc;
 //! use std::time::Duration;
 //! use parking_lot::ReentrantMutex;
@@ -71,9 +71,11 @@
 //! # #[tokio::main]
 //! # async fn main() {
 //! let output = Arc::new(ReentrantMutex::new(RefCell::new(UserOutput::new(VerbosityLevel::Normal))));
-//! let repository_factory = Arc::new(RepositoryFactory::new(Duration::from_secs(30)));
+//! let data_dir = PathBuf::from("./data");
+//! let repository_factory = RepositoryFactory::new(Duration::from_secs(30));
+//! let repository = repository_factory.create(data_dir);
 //! let clock = Arc::new(SystemClock);
-//! if let Err(e) = destroy::handle_destroy_command("test-env", Path::new("."), repository_factory, clock, &output).await {
+//! if let Err(e) = destroy::handle_destroy_command("test-env", repository, clock, &output).await {
 //!     eprintln!("Destroy failed: {e}");
 //!     eprintln!("\n{}", e.help());
 //! }

--- a/src/presentation/controllers/provision/errors.rs
+++ b/src/presentation/controllers/provision/errors.rs
@@ -121,10 +121,10 @@ impl ProvisionSubcommandError {
     ///
     /// # #[tokio::main]
     /// # async fn main() {
-    /// let container = Container::new(VerbosityLevel::Normal);
+    /// let container = Container::new(VerbosityLevel::Normal, Path::new("."));
     /// let context = ExecutionContext::new(Arc::new(container));
     ///
-    /// if let Err(e) = provision::handle("test-env", Path::new("."), &context).await {
+    /// if let Err(e) = provision::handle("test-env", &context).await {
     ///     eprintln!("Error: {e}");
     ///     eprintln!("\nTroubleshooting:\n{}", e.help());
     /// }
@@ -147,9 +147,11 @@ impl ProvisionSubcommandError {
     /// # #[tokio::main]
     /// # async fn main() {
     /// let output = Arc::new(ReentrantMutex::new(RefCell::new(UserOutput::new(VerbosityLevel::Normal))));
-    /// let repository_factory = Arc::new(RepositoryFactory::new(Duration::from_secs(30)));
+    /// let data_dir = PathBuf::from("./data");
+    /// let repository_factory = RepositoryFactory::new(Duration::from_secs(30));
+    /// let repository = repository_factory.create(data_dir);
     /// let clock = Arc::new(SystemClock);
-    /// if let Err(e) = provision::handle_provision_command("test-env", Path::new("."), repository_factory, clock, &output).await {
+    /// if let Err(e) = provision::handle_provision_command("test-env", repository, clock, &output).await {
     ///     eprintln!("Error: {e}");
     ///     eprintln!("\nTroubleshooting:\n{}", e.help());
     /// }

--- a/src/presentation/controllers/provision/handler.rs
+++ b/src/presentation/controllers/provision/handler.rs
@@ -13,7 +13,6 @@ use crate::domain::environment::name::EnvironmentName;
 use crate::domain::environment::repository::EnvironmentRepository;
 use crate::domain::environment::state::Provisioned;
 use crate::domain::environment::Environment;
-use crate::infrastructure::persistence::repository_factory::RepositoryFactory;
 use crate::presentation::dispatch::context::ExecutionContext;
 use crate::presentation::views::progress::ProgressReporter;
 use crate::presentation::views::UserOutput;
@@ -69,23 +68,20 @@ const PROVISION_WORKFLOW_STEPS: usize = 9;
 /// use torrust_tracker_deployer_lib::presentation::views::VerbosityLevel;
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// let container = Arc::new(Container::new(VerbosityLevel::Normal));
+/// let container = Arc::new(Container::new(VerbosityLevel::Normal, Path::new(".")));
 /// let context = ExecutionContext::new(container);
-/// let working_dir = Path::new("./test");
 ///
-/// provision::handle("my-env", working_dir, &context).await?;
+/// provision::handle("my-env", &context).await?;
 /// # Ok(())
 /// # }
 /// ```
 pub async fn handle(
     environment_name: &str,
-    working_dir: &std::path::Path,
     context: &ExecutionContext,
 ) -> Result<Environment<Provisioned>, ProvisionSubcommandError> {
     handle_provision_command(
         environment_name,
-        working_dir,
-        context.repository_factory(),
+        context.repository(),
         context.clock(),
         &context.user_output(),
     )
@@ -138,10 +134,10 @@ pub async fn handle(
 ///
 /// # #[tokio::main]
 /// # async fn main() {
-/// let container = Container::new(VerbosityLevel::Normal);
+/// let container = Container::new(VerbosityLevel::Normal, Path::new("."));
 /// let context = ExecutionContext::new(Arc::new(container));
 ///
-/// if let Err(e) = provision::handle("test-env", Path::new("."), &context).await {
+/// if let Err(e) = provision::handle("test-env", &context).await {
 ///     eprintln!("Provision failed: {e}");
 ///     eprintln!("Help: {}", e.help());
 /// }
@@ -157,16 +153,16 @@ pub async fn handle(
 /// use std::cell::RefCell;
 /// use torrust_tracker_deployer_lib::presentation::controllers::provision;
 /// use torrust_tracker_deployer_lib::presentation::views::{UserOutput, VerbosityLevel};
-/// use torrust_tracker_deployer_lib::infrastructure::persistence::repository_factory::RepositoryFactory;
-/// use torrust_tracker_deployer_lib::presentation::controllers::constants::DEFAULT_LOCK_TIMEOUT;
-/// use torrust_tracker_deployer_lib::shared::SystemClock;
+/// use torrust_tracker_deployer_lib::bootstrap::Container;
+/// use std::path::PathBuf;
 ///
 /// # #[tokio::main]
 /// # async fn main() {
+/// let container = Container::new(VerbosityLevel::Normal, Path::new("."));
 /// let user_output = Arc::new(ReentrantMutex::new(RefCell::new(UserOutput::new(VerbosityLevel::Normal))));
-/// let repository_factory = Arc::new(RepositoryFactory::new(DEFAULT_LOCK_TIMEOUT));
-/// let clock = Arc::new(SystemClock);
-/// if let Err(e) = provision::handle_provision_command("test-env", Path::new("."), repository_factory, clock, &user_output).await {
+/// let repository = container.repository();
+/// let clock = container.clock();
+/// if let Err(e) = provision::handle_provision_command("test-env", repository, clock, &user_output).await {
 ///     eprintln!("Provision failed: {e}");
 ///     eprintln!("Help: {}", e.help());
 /// }
@@ -176,19 +172,13 @@ pub async fn handle(
 #[allow(clippy::needless_pass_by_value)] // Arc parameters are moved to constructor for ownership
 pub async fn handle_provision_command(
     environment_name: &str,
-    working_dir: &std::path::Path,
-    repository_factory: Arc<RepositoryFactory>,
+    repository: Arc<dyn EnvironmentRepository + Send + Sync>,
     clock: Arc<dyn Clock>,
     user_output: &Arc<ReentrantMutex<RefCell<UserOutput>>>,
 ) -> Result<Environment<Provisioned>, ProvisionSubcommandError> {
-    ProvisionCommandController::new(
-        working_dir.to_path_buf(),
-        repository_factory,
-        clock,
-        user_output.clone(),
-    )
-    .execute(environment_name)
-    .await
+    ProvisionCommandController::new(repository, clock, user_output.clone())
+        .execute(environment_name)
+        .await
 }
 
 // ============================================================================
@@ -214,32 +204,27 @@ pub async fn handle_provision_command(
 /// `ProvisionCommandHandler`, maintaining clear separation of concerns.
 #[allow(unused)] // Temporary during refactoring
 pub struct ProvisionCommandController {
-    repository: Arc<dyn EnvironmentRepository>,
-    repository_factory: Arc<RepositoryFactory>,
+    repository: Arc<dyn EnvironmentRepository + Send + Sync>,
     clock: Arc<dyn Clock>,
     user_output: Arc<ReentrantMutex<RefCell<UserOutput>>>,
     progress: ProgressReporter,
 }
 
 impl ProvisionCommandController {
-    /// Create a new provision command controller from working directory
+    /// Create a new provision command controller
     ///
-    /// Creates a `ProvisionCommandController` with direct service injection from working directory and user output.
+    /// Creates a `ProvisionCommandController` with direct service injection.
     /// This follows the single container architecture pattern.
     #[allow(clippy::needless_pass_by_value)] // Constructor takes ownership of Arc parameters
     pub fn new(
-        working_dir: std::path::PathBuf,
-        repository_factory: Arc<RepositoryFactory>,
+        repository: Arc<dyn EnvironmentRepository + Send + Sync>,
         clock: Arc<dyn Clock>,
         user_output: Arc<ReentrantMutex<RefCell<UserOutput>>>,
     ) -> Self {
-        let data_dir = working_dir.join("data");
-        let repository = repository_factory.create(data_dir);
         let progress = ProgressReporter::new(user_output.clone(), PROVISION_WORKFLOW_STEPS);
 
         Self {
             repository,
-            repository_factory,
             clock,
             user_output,
             progress,
@@ -379,20 +364,25 @@ mod tests {
     ///
     /// Returns the common dependencies needed for testing `handle_provision_command`:
     /// - `user_output`: `ReentrantMutex`-wrapped `UserOutput` for thread-safe access
-    /// - `repository_factory`: Factory for creating environment repositories
+    /// - `repository`: Environment repository for persistence
     /// - `clock`: System clock for timing operations
     #[allow(clippy::type_complexity)] // Test helper with complex but clear types
-    fn create_test_dependencies() -> (
+    fn create_test_dependencies(
+        temp_dir: &tempfile::TempDir,
+    ) -> (
         Arc<ReentrantMutex<RefCell<UserOutput>>>,
-        Arc<RepositoryFactory>,
+        Arc<dyn EnvironmentRepository + Send + Sync>,
         Arc<dyn Clock>,
     ) {
+        use crate::infrastructure::persistence::repository_factory::RepositoryFactory;
         let (user_output, _, _) =
             TestUserOutput::new(VerbosityLevel::Normal).into_reentrant_wrapped();
-        let repository_factory = Arc::new(RepositoryFactory::new(DEFAULT_LOCK_TIMEOUT));
+        let data_dir = temp_dir.path().join("data");
+        let repository_factory = RepositoryFactory::new(DEFAULT_LOCK_TIMEOUT);
+        let repository = repository_factory.create(data_dir);
         let clock = Arc::new(SystemClock);
 
-        (user_output, repository_factory, clock)
+        (user_output, repository, clock)
     }
 
     #[tokio::test]
@@ -401,17 +391,11 @@ mod tests {
 
         let temp_dir = TempDir::new().unwrap();
 
-        let (user_output, repository_factory, clock) = create_test_dependencies();
+        let (user_output, repository, clock) = create_test_dependencies(&temp_dir);
 
         // Test with invalid environment name (contains underscore)
-        let result = handle_provision_command(
-            "invalid_name",
-            temp_dir.path(),
-            repository_factory,
-            clock,
-            &user_output,
-        )
-        .await;
+        let result =
+            handle_provision_command("invalid_name", repository, clock, &user_output).await;
 
         assert!(result.is_err());
         match result.unwrap_err() {
@@ -428,11 +412,9 @@ mod tests {
 
         let temp_dir = TempDir::new().unwrap();
 
-        let (user_output, repository_factory, clock) = create_test_dependencies();
+        let (user_output, repository, clock) = create_test_dependencies(&temp_dir);
 
-        let result =
-            handle_provision_command("", temp_dir.path(), repository_factory, clock, &user_output)
-                .await;
+        let result = handle_provision_command("", repository, clock, &user_output).await;
 
         assert!(result.is_err());
         match result.unwrap_err() {
@@ -449,23 +431,17 @@ mod tests {
 
         let temp_dir = TempDir::new().unwrap();
 
-        let (user_output, repository_factory, clock) = create_test_dependencies();
+        let (user_output, repository, clock) = create_test_dependencies(&temp_dir);
 
-        // Try to provision an environment that doesn't exist
-        let result = handle_provision_command(
-            "nonexistent-env",
-            temp_dir.path(),
-            repository_factory,
-            clock,
-            &user_output,
-        )
-        .await;
+        // Test environment that doesn't exist yet
+        let result =
+            handle_provision_command("non-existent-env", repository, clock, &user_output).await;
 
         assert!(result.is_err());
         // After refactoring, repository NotFound error is wrapped in ProvisionOperationFailed
         match result.unwrap_err() {
             ProvisionSubcommandError::ProvisionOperationFailed { name, .. } => {
-                assert_eq!(name, "nonexistent-env");
+                assert_eq!(name, "non-existent-env");
             }
             other => panic!("Expected ProvisionOperationFailed, got: {other:?}"),
         }
@@ -479,7 +455,7 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let working_dir = temp_dir.path();
 
-        let (user_output, repository_factory, clock) = create_test_dependencies();
+        let (user_output, repository, clock) = create_test_dependencies(&temp_dir);
 
         // Create a mock environment directory to test validation
         let env_dir = working_dir.join("test-env");
@@ -487,14 +463,7 @@ mod tests {
 
         // Valid environment name should pass validation, but will fail
         // at provision operation since we don't have a real environment setup
-        let result = handle_provision_command(
-            "test-env",
-            working_dir,
-            repository_factory,
-            clock,
-            &user_output,
-        )
-        .await;
+        let result = handle_provision_command("test-env", repository, clock, &user_output).await;
 
         // Should fail at operation, not at name validation
         if let Err(ProvisionSubcommandError::InvalidEnvironmentName { .. }) = result {

--- a/src/presentation/controllers/provision/mod.rs
+++ b/src/presentation/controllers/provision/mod.rs
@@ -26,11 +26,11 @@
 //! use torrust_tracker_deployer_lib::presentation::controllers::provision;
 //! use torrust_tracker_deployer_lib::presentation::views::VerbosityLevel;
 //!
-//! let container = Container::new(VerbosityLevel::Normal);
+//! let container = Container::new(VerbosityLevel::Normal, Path::new("."));
 //! let context = ExecutionContext::new(Arc::new(container));
 //!
 //! // Call the provision handler
-//! let result = provision::handler::handle("my-environment", Path::new("."), &context);
+//! let result = provision::handler::handle("my-environment", &context);
 //! ```
 //!
 //! ### Direct Usage (For Testing)
@@ -45,10 +45,10 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() {
-//! let container = Container::new(VerbosityLevel::Normal);
+//! let container = Container::new(VerbosityLevel::Normal, Path::new("."));
 //! let context = ExecutionContext::new(Arc::new(container));
 //!
-//! if let Err(e) = provision::handle("test-env", Path::new("."), &context).await {
+//! if let Err(e) = provision::handle("test-env", &context).await {
 //!     eprintln!("Provision failed: {e}");
 //!     eprintln!("\n{}", e.help());
 //! }
@@ -58,7 +58,7 @@
 //! ## Direct Usage (For Testing)
 //!
 //! ```rust
-//! use std::path::Path;
+//! use std::path::{Path, PathBuf};
 //! use std::sync::Arc;
 //! use std::time::Duration;
 //! use parking_lot::ReentrantMutex;
@@ -71,9 +71,11 @@
 //! # #[tokio::main]
 //! # async fn main() {
 //! let output = Arc::new(ReentrantMutex::new(RefCell::new(UserOutput::new(VerbosityLevel::Normal))));
-//! let repository_factory = Arc::new(RepositoryFactory::new(Duration::from_secs(30)));
+//! let data_dir = PathBuf::from("./data");
+//! let repository_factory = RepositoryFactory::new(Duration::from_secs(30));
+//! let repository = repository_factory.create(data_dir);
 //! let clock = Arc::new(SystemClock);
-//! if let Err(e) = provision::handle_provision_command("test-env", Path::new("."), repository_factory, clock, &output).await {
+//! if let Err(e) = provision::handle_provision_command("test-env", repository, clock, &output).await {
 //!     eprintln!("Provision failed: {e}");
 //!     eprintln!("\n{}", e.help());
 //! }

--- a/src/presentation/controllers/test/errors.rs
+++ b/src/presentation/controllers/test/errors.rs
@@ -110,10 +110,10 @@ impl TestSubcommandError {
     ///
     /// # #[tokio::main]
     /// # async fn main() {
-    /// let container = Container::new(VerbosityLevel::Normal);
+    /// let container = Container::new(VerbosityLevel::Normal, Path::new("."));
     /// let context = ExecutionContext::new(Arc::new(container));
     ///
-    /// if let Err(e) = test::handle("test-env", Path::new("."), &context).await {
+    /// if let Err(e) = test::handle("test-env", &context).await {
     ///     eprintln!("Error: {e}");
     ///     eprintln!("\nTroubleshooting:\n{}", e.help());
     /// }
@@ -123,7 +123,7 @@ impl TestSubcommandError {
     /// Direct usage (for testing):
     ///
     /// ```rust
-    /// use std::path::Path;
+    /// use std::path::{Path, PathBuf};
     /// use std::sync::Arc;
     /// use parking_lot::ReentrantMutex;
     /// use std::cell::RefCell;
@@ -135,8 +135,10 @@ impl TestSubcommandError {
     /// # #[tokio::main]
     /// # async fn main() {
     /// let output = Arc::new(ReentrantMutex::new(RefCell::new(UserOutput::new(VerbosityLevel::Normal))));
-    /// let repository_factory = Arc::new(RepositoryFactory::new(DEFAULT_LOCK_TIMEOUT));
-    /// if let Err(e) = test::handle_test_command("test-env", Path::new("."), repository_factory, &output).await {
+    /// let data_dir = PathBuf::from("./data");
+    /// let repository_factory = RepositoryFactory::new(DEFAULT_LOCK_TIMEOUT);
+    /// let repository = repository_factory.create(data_dir);
+    /// if let Err(e) = test::handle_test_command("test-env", repository, &output).await {
     ///     eprintln!("Error: {e}");
     ///     eprintln!("\nTroubleshooting:\n{}", e.help());
     /// }

--- a/src/presentation/controllers/test/mod.rs
+++ b/src/presentation/controllers/test/mod.rs
@@ -28,11 +28,11 @@
 //!
 //! # #[tokio::main]
 //! # async fn main() {
-//! let container = Container::new(VerbosityLevel::Normal);
+//! let container = Container::new(VerbosityLevel::Normal, Path::new("."));
 //! let context = ExecutionContext::new(Arc::new(container));
 //!
 //! // Call the test handler
-//! if let Err(e) = test::handle("my-environment", Path::new("."), &context).await {
+//! if let Err(e) = test::handle("my-environment", &context).await {
 //!     eprintln!("Test failed: {e}");
 //!     eprintln!("\n{}", e.help());
 //! }
@@ -42,7 +42,7 @@
 //! ## Direct Usage (For Testing)
 //!
 //! ```rust
-//! use std::path::Path;
+//! use std::path::{Path, PathBuf};
 //! use std::sync::Arc;
 //! use parking_lot::ReentrantMutex;
 //! use std::cell::RefCell;
@@ -54,8 +54,10 @@
 //! # #[tokio::main]
 //! # async fn main() {
 //! let output = Arc::new(ReentrantMutex::new(RefCell::new(UserOutput::new(VerbosityLevel::Normal))));
-//! let repository_factory = Arc::new(RepositoryFactory::new(DEFAULT_LOCK_TIMEOUT));
-//! if let Err(e) = test::handle_test_command("test-env", Path::new("."), repository_factory, &output).await {
+//! let data_dir = PathBuf::from("./data");
+//! let repository_factory = RepositoryFactory::new(DEFAULT_LOCK_TIMEOUT);
+//! let repository = repository_factory.create(data_dir);
+//! if let Err(e) = test::handle_test_command("test-env", repository, &output).await {
 //!     eprintln!("Test failed: {e}");
 //!     eprintln!("\n{}", e.help());
 //! }

--- a/src/presentation/dispatch/context.rs
+++ b/src/presentation/dispatch/context.rs
@@ -30,10 +30,11 @@
 //! use torrust_tracker_deployer_lib::presentation::views::VerbosityLevel;
 //! use torrust_tracker_deployer_lib::presentation::dispatch::ExecutionContext;
 //! use std::sync::Arc;
+//! use std::path::Path;
 //!
 //! # fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! // Create execution context from container
-//! let container = Container::new(VerbosityLevel::Normal);
+//! let container = Container::new(VerbosityLevel::Normal, Path::new("."));
 //! let context = ExecutionContext::new(Arc::new(container));
 //!
 //! // Command handlers access services through context
@@ -63,11 +64,12 @@ use crate::shared::clock::Clock;
 ///
 /// ```rust
 /// use std::sync::Arc;
+/// use std::path::Path;
 /// use torrust_tracker_deployer_lib::bootstrap::Container;
 /// use torrust_tracker_deployer_lib::presentation::views::VerbosityLevel;
 /// use torrust_tracker_deployer_lib::presentation::dispatch::ExecutionContext;
 ///
-/// let container = Arc::new(Container::new(VerbosityLevel::Normal));
+/// let container = Arc::new(Container::new(VerbosityLevel::Normal, Path::new(".")));
 /// let context = ExecutionContext::new(container);
 ///
 /// // Access user output service
@@ -93,9 +95,10 @@ impl ExecutionContext {
     /// use torrust_tracker_deployer_lib::presentation::views::VerbosityLevel;
     /// use torrust_tracker_deployer_lib::presentation::dispatch::ExecutionContext;
     /// use std::sync::Arc;
+    /// use std::path::Path;
     ///
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let container = Container::new(VerbosityLevel::Normal);
+    /// let container = Container::new(VerbosityLevel::Normal, Path::new("."));
     /// let context = ExecutionContext::new(Arc::new(container));
     /// # Ok(())
     /// # }
@@ -113,13 +116,14 @@ impl ExecutionContext {
     /// # Examples
     ///
     /// ```rust,no_run
+    /// use std::path::Path;
     /// use torrust_tracker_deployer_lib::bootstrap::Container;
     /// use torrust_tracker_deployer_lib::presentation::views::VerbosityLevel;
     /// use torrust_tracker_deployer_lib::presentation::dispatch::ExecutionContext;
     /// use std::sync::Arc;
     ///
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let container = Container::new(VerbosityLevel::Normal);
+    /// let container = Container::new(VerbosityLevel::Normal, Path::new("."));
     /// let context = ExecutionContext::new(Arc::new(container));
     ///
     /// let container_ref = context.container();
@@ -145,9 +149,10 @@ impl ExecutionContext {
     /// use torrust_tracker_deployer_lib::presentation::views::VerbosityLevel;
     /// use torrust_tracker_deployer_lib::presentation::dispatch::ExecutionContext;
     /// use std::sync::Arc;
+    /// use std::path::Path;
     ///
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let container = Container::new(VerbosityLevel::Normal);
+    /// let container = Container::new(VerbosityLevel::Normal, Path::new("."));
     /// let context = ExecutionContext::new(Arc::new(container));
     ///
     /// let user_output = context.user_output();
@@ -172,9 +177,10 @@ impl ExecutionContext {
     /// use torrust_tracker_deployer_lib::presentation::views::VerbosityLevel;
     /// use torrust_tracker_deployer_lib::presentation::dispatch::ExecutionContext;
     /// use std::sync::Arc;
+    /// use std::path::Path;
     ///
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let container = Container::new(VerbosityLevel::Normal);
+    /// let container = Container::new(VerbosityLevel::Normal, Path::new("."));
     /// let context = ExecutionContext::new(Arc::new(container));
     ///
     /// let repository_factory = context.repository_factory();
@@ -185,6 +191,36 @@ impl ExecutionContext {
     #[must_use]
     pub fn repository_factory(&self) -> Arc<RepositoryFactory> {
         self.container.repository_factory()
+    }
+
+    /// Get shared reference to environment repository
+    ///
+    /// Returns the environment repository for persistence operations.
+    /// The repository is wrapped in `Arc<dyn EnvironmentRepository>` for shared access.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use torrust_tracker_deployer_lib::bootstrap::Container;
+    /// use torrust_tracker_deployer_lib::presentation::views::VerbosityLevel;
+    /// use torrust_tracker_deployer_lib::presentation::dispatch::ExecutionContext;
+    /// use std::sync::Arc;
+    /// use std::path::Path;
+    ///
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let container = Container::new(VerbosityLevel::Normal, Path::new("."));
+    /// let context = ExecutionContext::new(Arc::new(container));
+    ///
+    /// let repository = context.repository();
+    /// // Use repository for environment persistence
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn repository(
+        &self,
+    ) -> Arc<dyn crate::domain::environment::repository::EnvironmentRepository + Send + Sync> {
+        self.container.repository()
     }
 
     /// Get shared reference to clock service
@@ -199,9 +235,10 @@ impl ExecutionContext {
     /// use torrust_tracker_deployer_lib::presentation::views::VerbosityLevel;
     /// use torrust_tracker_deployer_lib::presentation::dispatch::ExecutionContext;
     /// use std::sync::Arc;
+    /// use std::path::Path;
     ///
     /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let container = Container::new(VerbosityLevel::Normal);
+    /// let container = Container::new(VerbosityLevel::Normal, Path::new("."));
     /// let context = ExecutionContext::new(Arc::new(container));
     ///
     /// let clock = context.clock();

--- a/src/presentation/dispatch/router.rs
+++ b/src/presentation/dispatch/router.rs
@@ -114,19 +114,19 @@ pub async fn route_command(
             Ok(())
         }
         Commands::Destroy { environment } => {
-            destroy::handle(&environment, working_dir, context).await?;
+            destroy::handle(&environment, context).await?;
             Ok(())
         }
         Commands::Provision { environment } => {
-            provision::handle(&environment, working_dir, context).await?;
+            provision::handle(&environment, context).await?;
             Ok(())
         }
         Commands::Configure { environment } => {
-            configure::handle(&environment, working_dir, context).await?;
+            configure::handle(&environment, context).await?;
             Ok(())
         }
         Commands::Test { environment } => {
-            test::handle(&environment, working_dir, context).await?;
+            test::handle(&environment, context).await?;
             Ok(())
         } // Future commands will be added here as the Controller Layer expands:
           //

--- a/src/presentation/errors.rs
+++ b/src/presentation/errors.rs
@@ -145,7 +145,7 @@ impl CommandError {
             Self::Destroy(e) => e.help(),
             Self::Provision(e) => e.help(),
             Self::Configure(e) => e.help(),
-            Self::Test(e) => e.help(),
+            Self::Test(e) => e.as_ref().help(),
             Self::UserOutputLockFailed => {
                 "User Output Lock Failed - Detailed Troubleshooting:
 


### PR DESCRIPTION
## Summary

This PR implements the refactoring described in issue #194 to standardize repository injection across all presentation layer controllers.

## Changes

- **Container Enhancement**: Repository is now created once at startup using 
- **Standardized Injection**: All controllers now receive  directly
- **Removed Redundancy**: Eliminated  parameter from all controller handlers
- **Simplified API**: Removed unused  parameter from all handler functions
- **ExecutionContext Pattern**: Repository now accessible via  method

## Architecture

- Repository created in  using the working directory provided at initialization
- Controllers access repository through  for dependency injection
- Single repository instance shared across all controllers
- Repository path construction moved from controller layer to infrastructure layer

## Testing

- ✅ All 300 doctests pass
- ✅ All 1154 library tests pass
- ✅ All pre-commit checks pass (linting, formatting, E2E tests)

## Related

- Implements: #194
- See: docs/issues/194-refactor-repository-injection-in-controllers.md

---

**Implementation Details:**

1. Added  field to Container
2. Repository created once in  using 
3. Updated all controllers to accept repository directly instead of factory
4. Updated ExecutionContext to provide  accessor method
5. Removed unused  parameter from all handler functions
6. Updated all tests and doctests to reflect new API

This change simplifies the architecture and aligns with the single container pattern.