### PR TITLE
feat: [#207] update UserInputs to use ProviderConfig

### DIFF
--- a/src/application/command_handlers/create/config/mod.rs
+++ b/src/application/command_handlers/create/config/mod.rs
@@ -55,6 +55,8 @@
 //!     EnvironmentCreationConfig, EnvironmentSection, SshCredentialsConfig
 //! };
 //! use torrust_tracker_deployer_lib::domain::Environment;
+//! use torrust_tracker_deployer_lib::domain::provider::{LxdConfig, ProviderConfig};
+//! use torrust_tracker_deployer_lib::domain::ProfileName;
 //!
 //! // Deserialize configuration from JSON
 //! let json = r#"{
@@ -73,7 +75,10 @@
 //! let (name, credentials, port) = config.to_environment_params()?;
 //!
 //! // Create domain entity
-//! let environment = Environment::new(name, credentials, port);
+//! let provider_config = ProviderConfig::Lxd(LxdConfig {
+//!     profile_name: ProfileName::new(format!("lxd-{}", name.as_str())).unwrap(),
+//! });
+//! let environment = Environment::new(name, provider_config, credentials, port);
 //!
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```

--- a/src/application/command_handlers/create/tests/builders.rs
+++ b/src/application/command_handlers/create/tests/builders.rs
@@ -14,6 +14,8 @@ use crate::application::command_handlers::create::config::{
 };
 use crate::application::command_handlers::create::CreateCommandHandler;
 use crate::domain::environment::{Environment, EnvironmentName};
+use crate::domain::provider::{LxdConfig, ProviderConfig};
+use crate::domain::ProfileName;
 use crate::infrastructure::persistence::repository_factory::RepositoryFactory;
 use crate::shared::Clock;
 use crate::testing::MockClock;
@@ -204,8 +206,11 @@ impl CreateCommandHandlerTestBuilder {
         let env_name = EnvironmentName::new(name).expect("Invalid environment name in test");
         let username = Username::new("torrust".to_string()).expect("Invalid username in test");
         let ssh_credentials = SshCredentials::new(private_key, public_key, username);
+        let provider_config = ProviderConfig::Lxd(LxdConfig {
+            profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+        });
 
-        let environment = Environment::new(env_name, ssh_credentials, 22);
+        let environment = Environment::new(env_name, provider_config, ssh_credentials, 22);
 
         // Save to repository
         repository

--- a/src/domain/environment/state/configure_failed.rs
+++ b/src/domain/environment/state/configure_failed.rs
@@ -153,8 +153,16 @@ mod tests {
         use super::*;
         use crate::adapters::ssh::SshCredentials;
         use crate::domain::environment::name::EnvironmentName;
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
         use std::path::PathBuf;
+
+        fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+            ProviderConfig::Lxd(LxdConfig {
+                profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+            })
+        }
 
         fn create_test_ssh_credentials() -> SshCredentials {
             let username = Username::new("test-user".to_string()).unwrap();
@@ -168,11 +176,16 @@ mod tests {
         fn create_test_environment_configure_failed() -> Environment<ConfigureFailed> {
             let name = EnvironmentName::new("test-env".to_string()).unwrap();
             let ssh_creds = create_test_ssh_credentials();
-            Environment::new(name, ssh_creds, 22)
-                .start_provisioning()
-                .provisioned()
-                .start_configuring()
-                .configure_failed(super::create_test_context())
+            Environment::new(
+                name.clone(),
+                default_lxd_provider_config(&name),
+                ssh_creds,
+                22,
+            )
+            .start_provisioning()
+            .provisioned()
+            .start_configuring()
+            .configure_failed(super::create_test_context())
         }
 
         #[test]

--- a/src/domain/environment/state/configured.rs
+++ b/src/domain/environment/state/configured.rs
@@ -75,8 +75,16 @@ mod tests {
         use super::*;
         use crate::adapters::ssh::SshCredentials;
         use crate::domain::environment::name::EnvironmentName;
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
         use std::path::PathBuf;
+
+        fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+            ProviderConfig::Lxd(LxdConfig {
+                profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+            })
+        }
 
         fn create_test_ssh_credentials() -> SshCredentials {
             let username = Username::new("test-user".to_string()).unwrap();
@@ -90,11 +98,16 @@ mod tests {
         fn create_test_environment_configured() -> Environment<Configured> {
             let name = EnvironmentName::new("test-env".to_string()).unwrap();
             let ssh_creds = create_test_ssh_credentials();
-            Environment::new(name, ssh_creds, 22)
-                .start_provisioning()
-                .provisioned()
-                .start_configuring()
-                .configured()
+            Environment::new(
+                name.clone(),
+                default_lxd_provider_config(&name),
+                ssh_creds,
+                22,
+            )
+            .start_provisioning()
+            .provisioned()
+            .start_configuring()
+            .configured()
         }
 
         #[test]
@@ -118,8 +131,16 @@ mod tests {
         use crate::adapters::ssh::SshCredentials;
         use crate::domain::environment::name::EnvironmentName;
         use crate::domain::environment::state::Releasing;
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
         use std::path::PathBuf;
+
+        fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+            ProviderConfig::Lxd(LxdConfig {
+                profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+            })
+        }
 
         fn create_test_environment() -> Environment<Configured> {
             let env_name = EnvironmentName::new("test-state".to_string()).unwrap();
@@ -129,11 +150,16 @@ mod tests {
                 PathBuf::from("test_key.pub"),
                 ssh_username,
             );
-            Environment::new(env_name, ssh_credentials, 22)
-                .start_provisioning()
-                .provisioned()
-                .start_configuring()
-                .configured()
+            Environment::new(
+                env_name.clone(),
+                default_lxd_provider_config(&env_name),
+                ssh_credentials,
+                22,
+            )
+            .start_provisioning()
+            .provisioned()
+            .start_configuring()
+            .configured()
         }
 
         #[test]

--- a/src/domain/environment/state/configuring.rs
+++ b/src/domain/environment/state/configuring.rs
@@ -92,8 +92,16 @@ mod tests {
         use super::*;
         use crate::adapters::ssh::SshCredentials;
         use crate::domain::environment::name::EnvironmentName;
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
         use std::path::PathBuf;
+
+        fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+            ProviderConfig::Lxd(LxdConfig {
+                profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+            })
+        }
 
         fn create_test_ssh_credentials() -> SshCredentials {
             let username = Username::new("test-user".to_string()).unwrap();
@@ -107,10 +115,15 @@ mod tests {
         fn create_test_environment_configuring() -> Environment<Configuring> {
             let name = EnvironmentName::new("test-env".to_string()).unwrap();
             let ssh_creds = create_test_ssh_credentials();
-            Environment::new(name, ssh_creds, 22)
-                .start_provisioning()
-                .provisioned()
-                .start_configuring()
+            Environment::new(
+                name.clone(),
+                default_lxd_provider_config(&name),
+                ssh_creds,
+                22,
+            )
+            .start_provisioning()
+            .provisioned()
+            .start_configuring()
         }
 
         #[test]
@@ -134,8 +147,16 @@ mod tests {
         use crate::adapters::ssh::SshCredentials;
         use crate::domain::environment::name::EnvironmentName;
         use crate::domain::environment::state::Configured;
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
         use std::path::PathBuf;
+
+        fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+            ProviderConfig::Lxd(LxdConfig {
+                profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+            })
+        }
 
         fn create_test_environment() -> Environment<Configuring> {
             let env_name = EnvironmentName::new("test-state".to_string()).unwrap();
@@ -145,10 +166,15 @@ mod tests {
                 PathBuf::from("test_key.pub"),
                 ssh_username,
             );
-            Environment::new(env_name, ssh_credentials, 22)
-                .start_provisioning()
-                .provisioned()
-                .start_configuring()
+            Environment::new(
+                env_name.clone(),
+                default_lxd_provider_config(&env_name),
+                ssh_credentials,
+                22,
+            )
+            .start_provisioning()
+            .provisioned()
+            .start_configuring()
         }
 
         #[test]

--- a/src/domain/environment/state/created.rs
+++ b/src/domain/environment/state/created.rs
@@ -129,8 +129,16 @@ mod tests {
         use super::*;
         use crate::adapters::ssh::SshCredentials;
         use crate::domain::environment::name::EnvironmentName;
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
         use std::path::PathBuf;
+
+        fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+            ProviderConfig::Lxd(LxdConfig {
+                profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+            })
+        }
 
         fn create_test_ssh_credentials() -> SshCredentials {
             let username = Username::new("test-user".to_string()).unwrap();
@@ -144,7 +152,12 @@ mod tests {
         fn create_test_environment_created() -> Environment<Created> {
             let name = EnvironmentName::new("test-env".to_string()).unwrap();
             let ssh_creds = create_test_ssh_credentials();
-            Environment::new(name, ssh_creds, 22)
+            Environment::new(
+                name.clone(),
+                default_lxd_provider_config(&name),
+                ssh_creds,
+                22,
+            )
         }
 
         #[test]
@@ -193,8 +206,16 @@ mod tests {
         use crate::adapters::ssh::SshCredentials;
         use crate::domain::environment::name::EnvironmentName;
         use crate::domain::environment::state::Provisioning;
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
         use std::path::PathBuf;
+
+        fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+            ProviderConfig::Lxd(LxdConfig {
+                profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+            })
+        }
 
         fn create_test_ssh_credentials() -> SshCredentials {
             let username = Username::new("test-user".to_string()).unwrap();
@@ -208,7 +229,12 @@ mod tests {
         fn create_test_environment_created() -> Environment<Created> {
             let name = EnvironmentName::new("test-env".to_string()).unwrap();
             let ssh_creds = create_test_ssh_credentials();
-            Environment::new(name, ssh_creds, 22)
+            Environment::new(
+                name.clone(),
+                default_lxd_provider_config(&name),
+                ssh_creds,
+                22,
+            )
         }
 
         #[test]

--- a/src/domain/environment/state/destroy_failed.rs
+++ b/src/domain/environment/state/destroy_failed.rs
@@ -164,8 +164,16 @@ mod tests {
         use super::*;
         use crate::adapters::ssh::SshCredentials;
         use crate::domain::environment::name::EnvironmentName;
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
         use std::path::PathBuf;
+
+        fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+            ProviderConfig::Lxd(LxdConfig {
+                profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+            })
+        }
 
         fn create_test_ssh_credentials() -> SshCredentials {
             let username = Username::new("test-user".to_string()).unwrap();
@@ -179,11 +187,16 @@ mod tests {
         fn create_test_environment_destroy_failed() -> Environment<DestroyFailed> {
             let name = EnvironmentName::new("test-env".to_string()).unwrap();
             let ssh_creds = create_test_ssh_credentials();
-            Environment::new(name, ssh_creds, 22)
-                .start_provisioning()
-                .provisioned()
-                .start_destroying()
-                .destroy_failed(super::create_test_context())
+            Environment::new(
+                name.clone(),
+                default_lxd_provider_config(&name),
+                ssh_creds,
+                22,
+            )
+            .start_provisioning()
+            .provisioned()
+            .start_destroying()
+            .destroy_failed(super::create_test_context())
         }
 
         #[test]
@@ -206,11 +219,16 @@ mod tests {
             let name = EnvironmentName::new("test-env".to_string()).unwrap();
             let ssh_creds = create_test_ssh_credentials();
             let context = super::create_test_context();
-            let env = Environment::new(name, ssh_creds, 22)
-                .start_provisioning()
-                .provisioned()
-                .start_destroying()
-                .destroy_failed(context.clone());
+            let env = Environment::new(
+                name.clone(),
+                default_lxd_provider_config(&name),
+                ssh_creds,
+                22,
+            )
+            .start_provisioning()
+            .provisioned()
+            .start_destroying()
+            .destroy_failed(context.clone());
 
             // Round-trip conversion
             let any_env = env.into_any();

--- a/src/domain/environment/state/destroyed.rs
+++ b/src/domain/environment/state/destroyed.rs
@@ -62,8 +62,16 @@ mod tests {
         use super::*;
         use crate::adapters::ssh::SshCredentials;
         use crate::domain::environment::name::EnvironmentName;
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
         use std::path::PathBuf;
+
+        fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+            ProviderConfig::Lxd(LxdConfig {
+                profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+            })
+        }
 
         fn create_test_ssh_credentials() -> SshCredentials {
             let username = Username::new("test-user".to_string()).unwrap();
@@ -77,7 +85,13 @@ mod tests {
         fn create_test_environment_destroyed() -> Environment<Destroyed> {
             let name = EnvironmentName::new("test-env".to_string()).unwrap();
             let ssh_creds = create_test_ssh_credentials();
-            Environment::new(name, ssh_creds, 22).destroy()
+            Environment::new(
+                name.clone(),
+                default_lxd_provider_config(&name),
+                ssh_creds,
+                22,
+            )
+            .destroy()
         }
 
         #[test]

--- a/src/domain/environment/state/destroying.rs
+++ b/src/domain/environment/state/destroying.rs
@@ -92,8 +92,16 @@ mod tests {
         use super::*;
         use crate::adapters::ssh::SshCredentials;
         use crate::domain::environment::name::EnvironmentName;
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
         use std::path::PathBuf;
+
+        fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+            ProviderConfig::Lxd(LxdConfig {
+                profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+            })
+        }
 
         fn create_test_ssh_credentials() -> SshCredentials {
             let username = Username::new("test-user".to_string()).unwrap();
@@ -107,10 +115,15 @@ mod tests {
         fn create_test_environment_destroying() -> Environment<Destroying> {
             let name = EnvironmentName::new("test-env".to_string()).unwrap();
             let ssh_creds = create_test_ssh_credentials();
-            Environment::new(name, ssh_creds, 22)
-                .start_provisioning()
-                .provisioned()
-                .start_destroying()
+            Environment::new(
+                name.clone(),
+                default_lxd_provider_config(&name),
+                ssh_creds,
+                22,
+            )
+            .start_provisioning()
+            .provisioned()
+            .start_destroying()
         }
 
         #[test]
@@ -132,7 +145,12 @@ mod tests {
         fn it_should_fail_converting_created_to_destroying() {
             let name = EnvironmentName::new("test-env".to_string()).unwrap();
             let ssh_creds = create_test_ssh_credentials();
-            let env = Environment::new(name, ssh_creds, 22);
+            let env = Environment::new(
+                name.clone(),
+                default_lxd_provider_config(&name),
+                ssh_creds,
+                22,
+            );
             let any_env = env.into_any();
             let result = any_env.try_into_destroying();
             assert!(result.is_err());
@@ -147,8 +165,16 @@ mod tests {
         use crate::adapters::ssh::SshCredentials;
         use crate::domain::environment::name::EnvironmentName;
         use crate::domain::environment::state::Destroyed;
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
         use std::path::PathBuf;
+
+        fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+            ProviderConfig::Lxd(LxdConfig {
+                profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+            })
+        }
 
         fn create_test_ssh_credentials() -> SshCredentials {
             let username = Username::new("test-user".to_string()).unwrap();
@@ -162,10 +188,15 @@ mod tests {
         fn create_test_environment_destroying() -> Environment<Destroying> {
             let name = EnvironmentName::new("test-env".to_string()).unwrap();
             let ssh_creds = create_test_ssh_credentials();
-            Environment::new(name, ssh_creds, 22)
-                .start_provisioning()
-                .provisioned()
-                .start_destroying()
+            Environment::new(
+                name.clone(),
+                default_lxd_provider_config(&name),
+                ssh_creds,
+                22,
+            )
+            .start_provisioning()
+            .provisioned()
+            .start_destroying()
         }
 
         #[test]

--- a/src/domain/environment/state/provision_failed.rs
+++ b/src/domain/environment/state/provision_failed.rs
@@ -173,8 +173,16 @@ mod tests {
         use super::*;
         use crate::adapters::ssh::SshCredentials;
         use crate::domain::environment::name::EnvironmentName;
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
         use std::path::PathBuf;
+
+        fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+            ProviderConfig::Lxd(LxdConfig {
+                profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+            })
+        }
 
         fn create_test_ssh_credentials() -> SshCredentials {
             let username = Username::new("test-user".to_string()).unwrap();
@@ -188,9 +196,14 @@ mod tests {
         fn create_test_environment_provision_failed() -> Environment<ProvisionFailed> {
             let name = EnvironmentName::new("test-env".to_string()).unwrap();
             let ssh_creds = create_test_ssh_credentials();
-            Environment::new(name, ssh_creds, 22)
-                .start_provisioning()
-                .provision_failed(super::create_test_context())
+            Environment::new(
+                name.clone(),
+                default_lxd_provider_config(&name),
+                ssh_creds,
+                22,
+            )
+            .start_provisioning()
+            .provision_failed(super::create_test_context())
         }
 
         #[test]
@@ -213,9 +226,14 @@ mod tests {
             let name = EnvironmentName::new("test-env".to_string()).unwrap();
             let ssh_creds = create_test_ssh_credentials();
             let context = super::create_test_context();
-            let env = Environment::new(name, ssh_creds, 22)
-                .start_provisioning()
-                .provision_failed(context.clone());
+            let env = Environment::new(
+                name.clone(),
+                default_lxd_provider_config(&name),
+                ssh_creds,
+                22,
+            )
+            .start_provisioning()
+            .provision_failed(context.clone());
 
             // Round-trip conversion
             let any_env = env.into_any();

--- a/src/domain/environment/state/provisioned.rs
+++ b/src/domain/environment/state/provisioned.rs
@@ -76,8 +76,16 @@ mod tests {
         use crate::adapters::ssh::SshCredentials;
         use crate::domain::environment::name::EnvironmentName;
         use crate::domain::environment::state::ProvisionFailureContext;
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
         use std::path::PathBuf;
+
+        fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+            ProviderConfig::Lxd(LxdConfig {
+                profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+            })
+        }
 
         fn create_test_ssh_credentials() -> SshCredentials {
             let username = Username::new("test-user".to_string()).unwrap();
@@ -91,9 +99,14 @@ mod tests {
         fn create_test_environment_provisioned() -> Environment<Provisioned> {
             let name = EnvironmentName::new("test-env".to_string()).unwrap();
             let ssh_creds = create_test_ssh_credentials();
-            Environment::new(name, ssh_creds, 22)
-                .start_provisioning()
-                .provisioned()
+            Environment::new(
+                name.clone(),
+                default_lxd_provider_config(&name),
+                ssh_creds,
+                22,
+            )
+            .start_provisioning()
+            .provisioned()
         }
 
         fn create_test_provision_context() -> ProvisionFailureContext {
@@ -136,9 +149,14 @@ mod tests {
         fn it_should_fail_converting_provision_failed_to_provisioned() {
             let name = EnvironmentName::new("test-env".to_string()).unwrap();
             let ssh_creds = create_test_ssh_credentials();
-            let env = Environment::new(name, ssh_creds, 22)
-                .start_provisioning()
-                .provision_failed(create_test_provision_context());
+            let env = Environment::new(
+                name.clone(),
+                default_lxd_provider_config(&name),
+                ssh_creds,
+                22,
+            )
+            .start_provisioning()
+            .provision_failed(create_test_provision_context());
             let any_env = env.into_any();
             let result = any_env.try_into_provisioned();
             assert!(result.is_err());
@@ -153,8 +171,16 @@ mod tests {
         use crate::adapters::ssh::SshCredentials;
         use crate::domain::environment::name::EnvironmentName;
         use crate::domain::environment::state::{Configuring, Destroyed};
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
         use std::path::PathBuf;
+
+        fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+            ProviderConfig::Lxd(LxdConfig {
+                profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+            })
+        }
 
         fn create_test_environment() -> Environment<Provisioned> {
             let env_name = EnvironmentName::new("test-state".to_string()).unwrap();
@@ -164,9 +190,14 @@ mod tests {
                 PathBuf::from("test_key.pub"),
                 ssh_username,
             );
-            Environment::new(env_name, ssh_credentials, 22)
-                .start_provisioning()
-                .provisioned()
+            Environment::new(
+                env_name.clone(),
+                default_lxd_provider_config(&env_name),
+                ssh_credentials,
+                22,
+            )
+            .start_provisioning()
+            .provisioned()
         }
 
         #[test]

--- a/src/domain/environment/state/provisioning.rs
+++ b/src/domain/environment/state/provisioning.rs
@@ -92,8 +92,16 @@ mod tests {
         use super::*;
         use crate::adapters::ssh::SshCredentials;
         use crate::domain::environment::name::EnvironmentName;
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
         use std::path::PathBuf;
+
+        fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+            ProviderConfig::Lxd(LxdConfig {
+                profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+            })
+        }
 
         fn create_test_ssh_credentials() -> SshCredentials {
             let username = Username::new("test-user".to_string()).unwrap();
@@ -107,7 +115,13 @@ mod tests {
         fn create_test_environment_provisioning() -> Environment<Provisioning> {
             let name = EnvironmentName::new("test-env".to_string()).unwrap();
             let ssh_creds = create_test_ssh_credentials();
-            Environment::new(name, ssh_creds, 22).start_provisioning()
+            Environment::new(
+                name.clone(),
+                default_lxd_provider_config(&name),
+                ssh_creds,
+                22,
+            )
+            .start_provisioning()
         }
 
         #[test]
@@ -129,7 +143,12 @@ mod tests {
         fn it_should_fail_converting_created_to_provisioning() {
             let name = EnvironmentName::new("test-env".to_string()).unwrap();
             let ssh_creds = create_test_ssh_credentials();
-            let env = Environment::new(name, ssh_creds, 22);
+            let env = Environment::new(
+                name.clone(),
+                default_lxd_provider_config(&name),
+                ssh_creds,
+                22,
+            );
             let any_env = env.into_any();
             let result = any_env.try_into_provisioning();
             assert!(result.is_err());
@@ -144,8 +163,16 @@ mod tests {
         use crate::adapters::ssh::SshCredentials;
         use crate::domain::environment::name::EnvironmentName;
         use crate::domain::environment::state::Provisioned;
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
         use std::path::PathBuf;
+
+        fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+            ProviderConfig::Lxd(LxdConfig {
+                profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+            })
+        }
 
         fn create_test_ssh_credentials() -> SshCredentials {
             let username = Username::new("test-user".to_string()).unwrap();
@@ -159,7 +186,13 @@ mod tests {
         fn create_test_environment_provisioning() -> Environment<Provisioning> {
             let name = EnvironmentName::new("test-env".to_string()).unwrap();
             let ssh_creds = create_test_ssh_credentials();
-            Environment::new(name, ssh_creds, 22).start_provisioning()
+            Environment::new(
+                name.clone(),
+                default_lxd_provider_config(&name),
+                ssh_creds,
+                22,
+            )
+            .start_provisioning()
         }
 
         #[test]

--- a/src/domain/environment/state/release_failed.rs
+++ b/src/domain/environment/state/release_failed.rs
@@ -71,8 +71,16 @@ mod tests {
         use super::*;
         use crate::adapters::ssh::SshCredentials;
         use crate::domain::environment::name::EnvironmentName;
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
         use std::path::PathBuf;
+
+        fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+            ProviderConfig::Lxd(LxdConfig {
+                profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+            })
+        }
 
         fn create_test_ssh_credentials() -> SshCredentials {
             let username = Username::new("test-user".to_string()).unwrap();
@@ -86,13 +94,18 @@ mod tests {
         fn create_test_environment_release_failed() -> Environment<ReleaseFailed> {
             let name = EnvironmentName::new("test-env".to_string()).unwrap();
             let ssh_creds = create_test_ssh_credentials();
-            Environment::new(name, ssh_creds, 22)
-                .start_provisioning()
-                .provisioned()
-                .start_configuring()
-                .configured()
-                .start_releasing()
-                .release_failed("test error".to_string())
+            Environment::new(
+                name.clone(),
+                default_lxd_provider_config(&name),
+                ssh_creds,
+                22,
+            )
+            .start_provisioning()
+            .provisioned()
+            .start_configuring()
+            .configured()
+            .start_releasing()
+            .release_failed("test error".to_string())
         }
 
         #[test]

--- a/src/domain/environment/state/released.rs
+++ b/src/domain/environment/state/released.rs
@@ -73,8 +73,16 @@ mod tests {
         use super::*;
         use crate::adapters::ssh::SshCredentials;
         use crate::domain::environment::name::EnvironmentName;
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
         use std::path::PathBuf;
+
+        fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+            ProviderConfig::Lxd(LxdConfig {
+                profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+            })
+        }
 
         fn create_test_ssh_credentials() -> SshCredentials {
             let username = Username::new("test-user".to_string()).unwrap();
@@ -88,13 +96,18 @@ mod tests {
         fn create_test_environment_released() -> Environment<Released> {
             let name = EnvironmentName::new("test-env".to_string()).unwrap();
             let ssh_creds = create_test_ssh_credentials();
-            Environment::new(name, ssh_creds, 22)
-                .start_provisioning()
-                .provisioned()
-                .start_configuring()
-                .configured()
-                .start_releasing()
-                .released()
+            Environment::new(
+                name.clone(),
+                default_lxd_provider_config(&name),
+                ssh_creds,
+                22,
+            )
+            .start_provisioning()
+            .provisioned()
+            .start_configuring()
+            .configured()
+            .start_releasing()
+            .released()
         }
 
         #[test]
@@ -118,8 +131,16 @@ mod tests {
         use crate::adapters::ssh::SshCredentials;
         use crate::domain::environment::name::EnvironmentName;
         use crate::domain::environment::state::Running;
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
         use std::path::PathBuf;
+
+        fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+            ProviderConfig::Lxd(LxdConfig {
+                profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+            })
+        }
 
         fn create_test_environment() -> Environment<Released> {
             let env_name = EnvironmentName::new("test-state".to_string()).unwrap();
@@ -129,13 +150,18 @@ mod tests {
                 PathBuf::from("test_key.pub"),
                 ssh_username,
             );
-            Environment::new(env_name, ssh_credentials, 22)
-                .start_provisioning()
-                .provisioned()
-                .start_configuring()
-                .configured()
-                .start_releasing()
-                .released()
+            Environment::new(
+                env_name.clone(),
+                default_lxd_provider_config(&env_name),
+                ssh_credentials,
+                22,
+            )
+            .start_provisioning()
+            .provisioned()
+            .start_configuring()
+            .configured()
+            .start_releasing()
+            .released()
         }
 
         #[test]

--- a/src/domain/environment/state/releasing.rs
+++ b/src/domain/environment/state/releasing.rs
@@ -87,8 +87,16 @@ mod tests {
         use super::*;
         use crate::adapters::ssh::SshCredentials;
         use crate::domain::environment::name::EnvironmentName;
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
         use std::path::PathBuf;
+
+        fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+            ProviderConfig::Lxd(LxdConfig {
+                profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+            })
+        }
 
         fn create_test_ssh_credentials() -> SshCredentials {
             let username = Username::new("test-user".to_string()).unwrap();
@@ -102,12 +110,17 @@ mod tests {
         fn create_test_environment_releasing() -> Environment<Releasing> {
             let name = EnvironmentName::new("test-env".to_string()).unwrap();
             let ssh_creds = create_test_ssh_credentials();
-            Environment::new(name, ssh_creds, 22)
-                .start_provisioning()
-                .provisioned()
-                .start_configuring()
-                .configured()
-                .start_releasing()
+            Environment::new(
+                name.clone(),
+                default_lxd_provider_config(&name),
+                ssh_creds,
+                22,
+            )
+            .start_provisioning()
+            .provisioned()
+            .start_configuring()
+            .configured()
+            .start_releasing()
         }
 
         #[test]
@@ -131,8 +144,16 @@ mod tests {
         use crate::adapters::ssh::SshCredentials;
         use crate::domain::environment::name::EnvironmentName;
         use crate::domain::environment::state::Released;
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
         use std::path::PathBuf;
+
+        fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+            ProviderConfig::Lxd(LxdConfig {
+                profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+            })
+        }
 
         fn create_test_environment() -> Environment<Releasing> {
             let env_name = EnvironmentName::new("test-state".to_string()).unwrap();
@@ -142,12 +163,17 @@ mod tests {
                 PathBuf::from("test_key.pub"),
                 ssh_username,
             );
-            Environment::new(env_name, ssh_credentials, 22)
-                .start_provisioning()
-                .provisioned()
-                .start_configuring()
-                .configured()
-                .start_releasing()
+            Environment::new(
+                env_name.clone(),
+                default_lxd_provider_config(&env_name),
+                ssh_credentials,
+                22,
+            )
+            .start_provisioning()
+            .provisioned()
+            .start_configuring()
+            .configured()
+            .start_releasing()
         }
 
         #[test]

--- a/src/domain/environment/state/run_failed.rs
+++ b/src/domain/environment/state/run_failed.rs
@@ -71,8 +71,16 @@ mod tests {
         use super::*;
         use crate::adapters::ssh::SshCredentials;
         use crate::domain::environment::name::EnvironmentName;
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
         use std::path::PathBuf;
+
+        fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+            ProviderConfig::Lxd(LxdConfig {
+                profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+            })
+        }
 
         fn create_test_ssh_credentials() -> SshCredentials {
             let username = Username::new("test-user".to_string()).unwrap();
@@ -86,15 +94,20 @@ mod tests {
         fn create_test_environment_run_failed() -> Environment<RunFailed> {
             let name = EnvironmentName::new("test-env".to_string()).unwrap();
             let ssh_creds = create_test_ssh_credentials();
-            Environment::new(name, ssh_creds, 22)
-                .start_provisioning()
-                .provisioned()
-                .start_configuring()
-                .configured()
-                .start_releasing()
-                .released()
-                .start_running()
-                .run_failed("test error".to_string())
+            Environment::new(
+                name.clone(),
+                default_lxd_provider_config(&name),
+                ssh_creds,
+                22,
+            )
+            .start_provisioning()
+            .provisioned()
+            .start_configuring()
+            .configured()
+            .start_releasing()
+            .released()
+            .start_running()
+            .run_failed("test error".to_string())
         }
 
         #[test]

--- a/src/domain/environment/state/running.rs
+++ b/src/domain/environment/state/running.rs
@@ -77,8 +77,16 @@ mod tests {
         use super::*;
         use crate::adapters::ssh::SshCredentials;
         use crate::domain::environment::name::EnvironmentName;
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
         use std::path::PathBuf;
+
+        fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+            ProviderConfig::Lxd(LxdConfig {
+                profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+            })
+        }
 
         fn create_test_ssh_credentials() -> SshCredentials {
             let username = Username::new("test-user".to_string()).unwrap();
@@ -92,14 +100,19 @@ mod tests {
         fn create_test_environment_running() -> Environment<Running> {
             let name = EnvironmentName::new("test-env".to_string()).unwrap();
             let ssh_creds = create_test_ssh_credentials();
-            Environment::new(name, ssh_creds, 22)
-                .start_provisioning()
-                .provisioned()
-                .start_configuring()
-                .configured()
-                .start_releasing()
-                .released()
-                .start_running()
+            Environment::new(
+                name.clone(),
+                default_lxd_provider_config(&name),
+                ssh_creds,
+                22,
+            )
+            .start_provisioning()
+            .provisioned()
+            .start_configuring()
+            .configured()
+            .start_releasing()
+            .released()
+            .start_running()
         }
 
         #[test]
@@ -121,7 +134,13 @@ mod tests {
         fn it_should_fail_converting_destroyed_to_running() {
             let name = EnvironmentName::new("test-env".to_string()).unwrap();
             let ssh_creds = create_test_ssh_credentials();
-            let env = Environment::new(name, ssh_creds, 22).destroy();
+            let env = Environment::new(
+                name.clone(),
+                default_lxd_provider_config(&name),
+                ssh_creds,
+                22,
+            )
+            .destroy();
             let any_env = env.into_any();
             let result = any_env.try_into_running();
             assert!(result.is_err());
@@ -136,8 +155,16 @@ mod tests {
         use crate::adapters::ssh::SshCredentials;
         use crate::domain::environment::name::EnvironmentName;
         use crate::domain::environment::state::Destroyed;
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
         use std::path::PathBuf;
+
+        fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+            ProviderConfig::Lxd(LxdConfig {
+                profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+            })
+        }
 
         fn create_test_environment() -> Environment<Running> {
             let env_name = EnvironmentName::new("test-state".to_string()).unwrap();
@@ -147,14 +174,19 @@ mod tests {
                 PathBuf::from("test_key.pub"),
                 ssh_username,
             );
-            Environment::new(env_name, ssh_credentials, 22)
-                .start_provisioning()
-                .provisioned()
-                .start_configuring()
-                .configured()
-                .start_releasing()
-                .released()
-                .start_running()
+            Environment::new(
+                env_name.clone(),
+                default_lxd_provider_config(&env_name),
+                ssh_credentials,
+                22,
+            )
+            .start_provisioning()
+            .provisioned()
+            .start_configuring()
+            .configured()
+            .start_releasing()
+            .released()
+            .start_running()
         }
 
         #[test]

--- a/src/domain/environment/testing.rs
+++ b/src/domain/environment/testing.rs
@@ -5,6 +5,7 @@
 
 use super::*;
 use crate::adapters::ssh::SshCredentials;
+use crate::domain::provider::{LxdConfig, ProviderConfig};
 use crate::domain::EnvironmentName;
 use crate::shared::Username;
 use std::path::{Path, PathBuf};
@@ -128,12 +129,13 @@ impl EnvironmentTestBuilder {
         let instance_name =
             InstanceName::new(format!("torrust-tracker-vm-{}", env_name.as_str())).unwrap();
         let profile_name = ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap();
+        let provider_config = ProviderConfig::Lxd(LxdConfig { profile_name });
 
         let context = EnvironmentContext {
             user_inputs: crate::domain::environment::UserInputs {
                 name: env_name,
                 instance_name,
-                profile_name,
+                provider_config,
                 ssh_credentials,
                 ssh_port: 22,
             },

--- a/src/domain/environment/user_inputs.rs
+++ b/src/domain/environment/user_inputs.rs
@@ -20,7 +20,8 @@
 
 use crate::adapters::ssh::SshCredentials;
 use crate::domain::environment::EnvironmentName;
-use crate::domain::{InstanceName, ProfileName};
+use crate::domain::provider::{Provider, ProviderConfig};
+use crate::domain::InstanceName;
 use serde::{Deserialize, Serialize};
 
 /// User-provided configuration when creating an environment
@@ -32,16 +33,21 @@ use serde::{Deserialize, Serialize};
 /// # Examples
 ///
 /// ```rust
-/// use torrust_tracker_deployer_lib::domain::{InstanceName, ProfileName, EnvironmentName};
+/// use torrust_tracker_deployer_lib::domain::{InstanceName, EnvironmentName, ProfileName};
+/// use torrust_tracker_deployer_lib::domain::provider::{ProviderConfig, LxdConfig};
 /// use torrust_tracker_deployer_lib::domain::environment::user_inputs::UserInputs;
 /// use torrust_tracker_deployer_lib::shared::Username;
 /// use torrust_tracker_deployer_lib::adapters::ssh::SshCredentials;
 /// use std::path::PathBuf;
 ///
+/// let provider_config = ProviderConfig::Lxd(LxdConfig {
+///     profile_name: ProfileName::new("torrust-profile-production".to_string())?,
+/// });
+///
 /// let user_inputs = UserInputs {
 ///     name: EnvironmentName::new("production".to_string())?,
 ///     instance_name: InstanceName::new("torrust-tracker-vm-production".to_string())?,
-///     profile_name: ProfileName::new("torrust-profile-production".to_string())?,
+///     provider_config,
 ///     ssh_credentials: SshCredentials::new(
 ///         PathBuf::from("keys/prod_rsa"),
 ///         PathBuf::from("keys/prod_rsa.pub"),
@@ -59,8 +65,8 @@ pub struct UserInputs {
     /// The instance name for this environment (auto-generated from name)
     pub instance_name: InstanceName,
 
-    /// The profile name for this environment (auto-generated from name)
-    pub profile_name: ProfileName,
+    /// Provider-specific configuration (e.g., LXD profile, Hetzner settings)
+    pub provider_config: ProviderConfig,
 
     /// SSH credentials for connecting to instances in this environment
     pub ssh_credentials: SshCredentials,
@@ -70,11 +76,12 @@ pub struct UserInputs {
 }
 
 impl UserInputs {
-    /// Creates a new `UserInputs` with auto-generated instance and profile names
+    /// Creates a new `UserInputs` with auto-generated instance name
     ///
     /// # Arguments
     ///
     /// * `name` - The validated environment name
+    /// * `provider_config` - Provider-specific configuration
     /// * `ssh_credentials` - SSH credentials for connecting to instances
     /// * `ssh_port` - SSH port for connecting to instances
     ///
@@ -82,12 +89,13 @@ impl UserInputs {
     ///
     /// A new `UserInputs` with:
     /// - Auto-generated instance name: `torrust-tracker-vm-{env_name}`
-    /// - Auto-generated profile name: `torrust-profile-{env_name}`
     ///
     /// # Examples
     ///
     /// ```rust
     /// use torrust_tracker_deployer_lib::domain::environment::{EnvironmentName, UserInputs};
+    /// use torrust_tracker_deployer_lib::domain::provider::{ProviderConfig, LxdConfig, Provider};
+    /// use torrust_tracker_deployer_lib::domain::ProfileName;
     /// use torrust_tracker_deployer_lib::shared::Username;
     /// use torrust_tracker_deployer_lib::adapters::ssh::SshCredentials;
     /// use std::path::PathBuf;
@@ -99,11 +107,14 @@ impl UserInputs {
     ///     PathBuf::from("keys/prod_rsa.pub"),
     ///     ssh_username,
     /// );
+    /// let provider_config = ProviderConfig::Lxd(LxdConfig {
+    ///     profile_name: ProfileName::new("torrust-profile-production".to_string())?,
+    /// });
     ///
-    /// let user_inputs = UserInputs::new(&env_name, ssh_credentials, 22);
+    /// let user_inputs = UserInputs::new(&env_name, provider_config, ssh_credentials, 22);
     ///
     /// assert_eq!(user_inputs.instance_name.as_str(), "torrust-tracker-vm-production");
-    /// assert_eq!(user_inputs.profile_name.as_str(), "torrust-profile-production");
+    /// assert_eq!(user_inputs.provider(), Provider::Lxd);
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
@@ -113,17 +124,70 @@ impl UserInputs {
     /// This function does not panic. All name generation is guaranteed to succeed
     /// for valid environment names.
     #[must_use]
-    pub fn new(name: &EnvironmentName, ssh_credentials: SshCredentials, ssh_port: u16) -> Self {
+    pub fn new(
+        name: &EnvironmentName,
+        provider_config: ProviderConfig,
+        ssh_credentials: SshCredentials,
+        ssh_port: u16,
+    ) -> Self {
         let instance_name = Self::generate_instance_name(name);
-        let profile_name = Self::generate_profile_name(name);
 
         Self {
             name: name.clone(),
             instance_name,
-            profile_name,
+            provider_config,
             ssh_credentials,
             ssh_port,
         }
+    }
+
+    // ========================================================================
+    // Provider Accessor Methods
+    // ========================================================================
+
+    /// Returns the provider type for this environment
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use torrust_tracker_deployer_lib::domain::environment::{EnvironmentName, UserInputs};
+    /// use torrust_tracker_deployer_lib::domain::provider::{ProviderConfig, LxdConfig, Provider};
+    /// use torrust_tracker_deployer_lib::domain::ProfileName;
+    /// use torrust_tracker_deployer_lib::shared::Username;
+    /// use torrust_tracker_deployer_lib::adapters::ssh::SshCredentials;
+    /// use std::path::PathBuf;
+    ///
+    /// let env_name = EnvironmentName::new("test".to_string())?;
+    /// let ssh_credentials = SshCredentials::new(
+    ///     PathBuf::from("keys/test_rsa"),
+    ///     PathBuf::from("keys/test_rsa.pub"),
+    ///     Username::new("torrust".to_string())?,
+    /// );
+    /// let provider_config = ProviderConfig::Lxd(LxdConfig {
+    ///     profile_name: ProfileName::new("test-profile".to_string())?,
+    /// });
+    ///
+    /// let user_inputs = UserInputs::new(&env_name, provider_config, ssh_credentials, 22);
+    /// assert_eq!(user_inputs.provider(), Provider::Lxd);
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[must_use]
+    pub fn provider(&self) -> Provider {
+        self.provider_config.provider()
+    }
+
+    /// Returns a reference to the provider configuration
+    ///
+    /// Use this to access provider-specific fields. For example:
+    /// ```rust,ignore
+    /// if let Some(lxd_config) = user_inputs.provider_config().as_lxd() {
+    ///     println!("LXD profile: {}", lxd_config.profile_name.as_str());
+    /// }
+    /// ```
+    #[must_use]
+    pub fn provider_config(&self) -> &ProviderConfig {
+        &self.provider_config
     }
 
     // ========================================================================
@@ -143,17 +207,94 @@ impl UserInputs {
         InstanceName::new(instance_name_str)
             .expect("Generated instance name should always be valid")
     }
+}
 
-    /// Generates a profile name from the environment name
-    ///
-    /// Format: `torrust-profile-{env_name}`
-    ///
-    /// # Panics
-    ///
-    /// This function does not panic. The generated profile name is guaranteed
-    /// to be valid for any valid environment name.
-    fn generate_profile_name(env_name: &EnvironmentName) -> ProfileName {
-        let profile_name_str = format!("torrust-profile-{}", env_name.as_str());
-        ProfileName::new(profile_name_str).expect("Generated profile name should always be valid")
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::provider::LxdConfig;
+    use crate::domain::ProfileName;
+    use crate::shared::Username;
+    use std::path::PathBuf;
+
+    fn create_test_ssh_credentials() -> SshCredentials {
+        SshCredentials::new(
+            PathBuf::from("keys/test_rsa"),
+            PathBuf::from("keys/test_rsa.pub"),
+            Username::new("testuser".to_string()).unwrap(),
+        )
+    }
+
+    fn create_lxd_provider_config(profile_name: &str) -> ProviderConfig {
+        ProviderConfig::Lxd(LxdConfig {
+            profile_name: ProfileName::new(profile_name.to_string()).unwrap(),
+        })
+    }
+
+    #[test]
+    fn it_should_create_user_inputs_with_lxd_provider() {
+        let env_name = EnvironmentName::new("test-env".to_string()).unwrap();
+        let provider_config = create_lxd_provider_config("test-profile");
+        let ssh_credentials = create_test_ssh_credentials();
+
+        let user_inputs = UserInputs::new(&env_name, provider_config, ssh_credentials, 22);
+
+        assert_eq!(user_inputs.name.as_str(), "test-env");
+        assert_eq!(
+            user_inputs.instance_name.as_str(),
+            "torrust-tracker-vm-test-env"
+        );
+        assert_eq!(user_inputs.provider(), Provider::Lxd);
+        assert_eq!(user_inputs.provider_config().provider_name(), "lxd");
+        assert_eq!(user_inputs.ssh_port, 22);
+    }
+
+    #[test]
+    fn it_should_return_provider_config_for_lxd() {
+        let env_name = EnvironmentName::new("test-env".to_string()).unwrap();
+        let provider_config = create_lxd_provider_config("my-custom-profile");
+        let ssh_credentials = create_test_ssh_credentials();
+
+        let user_inputs = UserInputs::new(&env_name, provider_config, ssh_credentials, 22);
+
+        let lxd_config = user_inputs.provider_config().as_lxd().unwrap();
+        assert_eq!(lxd_config.profile_name.as_str(), "my-custom-profile");
+    }
+
+    #[test]
+    fn it_should_return_provider_config_for_hetzner() {
+        use crate::domain::provider::HetznerConfig;
+
+        let env_name = EnvironmentName::new("test-env".to_string()).unwrap();
+        let provider_config = ProviderConfig::Hetzner(HetznerConfig {
+            api_token: "test-token".to_string(),
+            server_type: "cx22".to_string(),
+            location: "nbg1".to_string(),
+        });
+        let ssh_credentials = create_test_ssh_credentials();
+
+        let user_inputs = UserInputs::new(&env_name, provider_config, ssh_credentials, 22);
+
+        assert_eq!(user_inputs.provider(), Provider::Hetzner);
+        assert!(user_inputs.provider_config().as_lxd().is_none());
+
+        let hetzner_config = user_inputs.provider_config().as_hetzner().unwrap();
+        assert_eq!(hetzner_config.api_token, "test-token");
+        assert_eq!(hetzner_config.server_type, "cx22");
+        assert_eq!(hetzner_config.location, "nbg1");
+    }
+
+    #[test]
+    fn it_should_auto_generate_instance_name_from_environment_name() {
+        let env_name = EnvironmentName::new("production".to_string()).unwrap();
+        let provider_config = create_lxd_provider_config("prod-profile");
+        let ssh_credentials = create_test_ssh_credentials();
+
+        let user_inputs = UserInputs::new(&env_name, provider_config, ssh_credentials, 22);
+
+        assert_eq!(
+            user_inputs.instance_name.as_str(),
+            "torrust-tracker-vm-production"
+        );
     }
 }

--- a/src/infrastructure/persistence/filesystem/file_environment_repository.rs
+++ b/src/infrastructure/persistence/filesystem/file_environment_repository.rs
@@ -172,11 +172,19 @@ mod tests {
     use super::*;
     use crate::adapters::ssh::credentials::SshCredentials;
     use crate::domain::environment::Environment;
+    use crate::domain::provider::{LxdConfig, ProviderConfig};
+    use crate::domain::ProfileName;
     use crate::shared::Username;
     use rstest::rstest;
     use std::error::Error as StdError;
     use std::path::PathBuf;
     use tempfile::TempDir;
+
+    fn default_lxd_provider_config(env_name: &EnvironmentName) -> ProviderConfig {
+        ProviderConfig::Lxd(LxdConfig {
+            profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+        })
+    }
 
     fn create_test_ssh_credentials() -> SshCredentials {
         let username = Username::new("test-user".to_string()).unwrap();
@@ -190,7 +198,12 @@ mod tests {
     fn create_test_environment(name: &str) -> Environment {
         let env_name = EnvironmentName::new(name.to_string()).unwrap();
         let ssh_credentials = create_test_ssh_credentials();
-        Environment::new(env_name, ssh_credentials, 22)
+        Environment::new(
+            env_name.clone(),
+            default_lxd_provider_config(&env_name),
+            ssh_credentials,
+            22,
+        )
     }
 
     #[test]

--- a/src/infrastructure/persistence/repository_factory.rs
+++ b/src/infrastructure/persistence/repository_factory.rs
@@ -146,6 +146,8 @@ mod tests {
         #[allow(unused_imports)] // Needed for trait methods on Arc<dyn EnvironmentRepository>
         use crate::domain::environment::repository::EnvironmentRepository;
         use crate::domain::environment::{Environment, EnvironmentName};
+        use crate::domain::provider::{LxdConfig, ProviderConfig};
+        use crate::domain::ProfileName;
         use crate::shared::Username;
 
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
@@ -159,7 +161,10 @@ mod tests {
             temp_dir.path().join("test_key.pub"),
             Username::new("test_user").expect("Valid username"),
         );
-        let environment = Environment::new(env_name.clone(), ssh_credentials, 22);
+        let provider_config = ProviderConfig::Lxd(LxdConfig {
+            profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+        });
+        let environment = Environment::new(env_name.clone(), provider_config, ssh_credentials, 22);
 
         // Create repository with temp directory as base (not environment-specific directory)
         // The repository will automatically create the environment subdirectory

--- a/src/testing/e2e/context.rs
+++ b/src/testing/e2e/context.rs
@@ -177,6 +177,8 @@ impl TestContext {
     ///
     /// ```rust,no_run
     /// use torrust_tracker_deployer_lib::domain::{Environment, EnvironmentName};
+    /// use torrust_tracker_deployer_lib::domain::provider::{LxdConfig, ProviderConfig};
+    /// use torrust_tracker_deployer_lib::domain::ProfileName;
     /// use torrust_tracker_deployer_lib::shared::Username;
     /// use torrust_tracker_deployer_lib::adapters::ssh::SshCredentials;
     /// use torrust_tracker_deployer_lib::testing::e2e::context::{TestContext, TestContextType};
@@ -194,7 +196,10 @@ impl TestContext {
     ///     temp_path.join("testing_rsa.pub"),
     ///     ssh_username,
     /// );
-    /// let environment = Environment::new(env_name, ssh_credentials, 22);
+    /// let provider_config = ProviderConfig::Lxd(LxdConfig {
+    ///     profile_name: ProfileName::new(format!("lxd-{}", env_name.as_str())).unwrap(),
+    /// });
+    /// let environment = Environment::new(env_name, provider_config, ssh_credentials, 22);
     ///
     /// let test_context = TestContext::from_environment(
     ///     false,


### PR DESCRIPTION
## Summary

Refactor `UserInputs` struct to include provider configuration, making provider-specific settings explicit and extensible.

Closes #207

## Changes

### Domain Layer

- Add `provider_config: ProviderConfig` field to `UserInputs`
- Remove `profile_name` field (now in `LxdConfig` via `ProviderConfig`)
- Add only two accessor methods:
  - `provider()` - returns the `Provider` enum variant
  - `provider_config()` - returns `&ProviderConfig` for accessing provider-specific fields

### Application Layer

- Update `EnvironmentContext` to accept `ProviderConfig` in `new()` and `with_working_dir()`
- Update `Environment::new()` and `with_working_dir()` to accept `ProviderConfig`
- Create handler generates default LXD `ProviderConfig` from environment name (temporary until issue #208 wires up JSON config)

## Key Design Decisions

1. **Minimal accessor methods**: `UserInputs` exposes only `provider()` and `provider_config()` accessors
2. **No provider-specific accessors**: Callers extract provider-specific fields via `provider_config().as_lxd()` pattern
3. **Scalability**: Avoids method proliferation (e.g., no `lxd_profile_name()`, `hetzner_api_token()`) - with 10 providers × 10 fields, this would be 100+ methods
4. **Backward compatibility**: `Environment::profile_name()` still exists but accesses `LxdConfig` via `provider_config()`

## Usage Example

```rust
// Access provider type
let provider = user_inputs.provider();

// Access provider-specific config
if let Some(lxd_config) = user_inputs.provider_config().as_lxd() {
    println!("LXD profile: {}", lxd_config.profile_name.as_str());
}
```

## Testing

- All 1218 unit tests pass
- All E2E tests pass
- Pre-commit checks pass