### PR TITLE
feat: [#208] Add provider configuration to EnvironmentCreationConfig

### DIFF
--- a/docs/user-guide/commands/create.md
+++ b/docs/user-guide/commands/create.md
@@ -20,7 +20,7 @@ Generate a JSON configuration template file with placeholder values.
 #### Syntax
 
 ```bash
-torrust-tracker-deployer create template [OUTPUT_PATH]
+torrust-tracker-deployer create template --provider <PROVIDER> [OUTPUT_PATH]
 ```
 
 #### Arguments
@@ -29,36 +29,108 @@ torrust-tracker-deployer create template [OUTPUT_PATH]
   - Default: `environment-template.json` in current directory
   - Parent directories will be created automatically if they don't exist
 
+#### Options
+
+- `--provider`, `-p` (**required**) - Provider to generate template for
+  - Values: `lxd`, `hetzner`
+
 #### Examples
 
-**Generate template in current directory**:
+**Generate LXD template**:
 
 ```bash
-torrust-tracker-deployer create template
-# Creates: ./environment-template.json
+torrust-tracker-deployer create template --provider lxd
+# Creates: ./environment-template.json (LXD template)
+```
+
+**Generate Hetzner template**:
+
+```bash
+torrust-tracker-deployer create template --provider hetzner
+# Creates: ./environment-template.json (Hetzner template)
 ```
 
 **Generate template with custom path**:
 
 ```bash
-torrust-tracker-deployer create template config/my-env.json
+torrust-tracker-deployer create template --provider lxd config/my-env.json
 # Creates: ./config/my-env.json
+```
+
+**Generate Hetzner template with custom path**:
+
+```bash
+torrust-tracker-deployer create template --provider hetzner config/hetzner-env.json
+# Creates: ./config/hetzner-env.json (Hetzner template)
 ```
 
 **Generate template in specific directory**:
 
 ```bash
-torrust-tracker-deployer create template /path/to/configs/production.json
+torrust-tracker-deployer create template --provider lxd /path/to/configs/production.json
 # Creates: /path/to/configs/production.json
+```
+
+**Using short flag for provider**:
+
+```bash
+torrust-tracker-deployer create template -p hetzner my-config.json
+# Creates: ./my-config.json (Hetzner template)
 ```
 
 #### Template Structure
 
-The generated template includes:
+The generated template includes provider-specific placeholders:
+
+**LXD Template**:
+
+```json
+{
+  "environment": {
+    "name": "REPLACE_WITH_ENVIRONMENT_NAME"
+  },
+  "ssh_credentials": {
+    "private_key_path": "REPLACE_WITH_SSH_PRIVATE_KEY_ABSOLUTE_PATH",
+    "public_key_path": "REPLACE_WITH_SSH_PUBLIC_KEY_ABSOLUTE_PATH",
+    "username": "torrust",
+    "port": 22
+  },
+  "provider": {
+    "provider": "lxd",
+    "profile_name": "REPLACE_WITH_LXD_PROFILE_NAME"
+  }
+}
+```
+
+**Hetzner Template**:
+
+```json
+{
+  "environment": {
+    "name": "REPLACE_WITH_ENVIRONMENT_NAME"
+  },
+  "ssh_credentials": {
+    "private_key_path": "REPLACE_WITH_SSH_PRIVATE_KEY_ABSOLUTE_PATH",
+    "public_key_path": "REPLACE_WITH_SSH_PUBLIC_KEY_ABSOLUTE_PATH",
+    "username": "torrust",
+    "port": 22
+  },
+  "provider": {
+    "provider": "hetzner",
+    "api_token": "REPLACE_WITH_HETZNER_API_TOKEN",
+    "server_type": "cx22",
+    "location": "nbg1"
+  }
+}
+```
+
+#### Workflow Example
 
 ```bash
-# Step 1: Generate configuration template
-torrust-tracker-deployer create template config.json
+# Step 1: Generate configuration template (choose your provider)
+torrust-tracker-deployer create template --provider lxd config.json
+# Or for Hetzner:
+# torrust-tracker-deployer create template --provider hetzner config.json
 
 # Step 2: Edit the configuration file
 nano config.json
@@ -527,18 +599,34 @@ After creating an environment, the typical workflow is:
 For convenience, use the `create template` command to generate a configuration template:
 
 ```bash
-# Generate template with default name
-torrust-tracker-deployer create template
+# Generate LXD template
+torrust-tracker-deployer create template --provider lxd
 
-# Generate template with custom name
-torrust-tracker-deployer create template my-config.json
+# Generate Hetzner template
+torrust-tracker-deployer create template --provider hetzner
+
+# Generate LXD template with custom name
+torrust-tracker-deployer create template --provider lxd my-config.json
+
+# Generate Hetzner template with custom name
+torrust-tracker-deployer create template --provider hetzner my-config.json
 ```
 
 The template will contain placeholder values that you need to replace:
 
+**Common placeholders (all providers)**:
+
 - `REPLACE_WITH_ENVIRONMENT_NAME` - Choose a unique environment name
 - `REPLACE_WITH_SSH_PRIVATE_KEY_ABSOLUTE_PATH` - Path to your SSH private key
 - `REPLACE_WITH_SSH_PUBLIC_KEY_ABSOLUTE_PATH` - Path to your SSH public key
+
+**LXD-specific placeholders**:
+
+- `REPLACE_WITH_LXD_PROFILE_NAME` - Your LXD profile name
+
+**Hetzner-specific placeholders**:
+
+- `REPLACE_WITH_HETZNER_API_TOKEN` - Your Hetzner API token
 
 Edit the generated template and then use it to create your environment.
 

--- a/src/application/command_handlers/create/config/mod.rs
+++ b/src/application/command_handlers/create/config/mod.rs
@@ -52,11 +52,10 @@
 //!
 //! ```rust
 //! use torrust_tracker_deployer_lib::application::command_handlers::create::config::{
-//!     EnvironmentCreationConfig, EnvironmentSection, SshCredentialsConfig
+//!     EnvironmentCreationConfig, EnvironmentSection, SshCredentialsConfig,
+//!     ProviderSection, LxdProviderSection
 //! };
 //! use torrust_tracker_deployer_lib::domain::Environment;
-//! use torrust_tracker_deployer_lib::domain::provider::{LxdConfig, ProviderConfig};
-//! use torrust_tracker_deployer_lib::domain::ProfileName;
 //!
 //! // Deserialize configuration from JSON
 //! let json = r#"{
@@ -66,18 +65,19 @@
 //!     "ssh_credentials": {
 //!         "private_key_path": "fixtures/testing_rsa",
 //!         "public_key_path": "fixtures/testing_rsa.pub"
+//!     },
+//!     "provider": {
+//!         "provider": "lxd",
+//!         "profile_name": "torrust-profile-dev"
 //!     }
 //! }"#;
 //!
 //! let config: EnvironmentCreationConfig = serde_json::from_str(json)?;
 //!
 //! // Convert to domain parameters
-//! let (name, credentials, port) = config.to_environment_params()?;
+//! let (name, instance_name, provider_config, credentials, port) = config.to_environment_params()?;
 //!
-//! // Create domain entity
-//! let provider_config = ProviderConfig::Lxd(LxdConfig {
-//!     profile_name: ProfileName::new(format!("lxd-{}", name.as_str())).unwrap(),
-//! });
+//! // Create domain entity - Environment::new() will use the provider_config
 //! let environment = Environment::new(name, provider_config, credentials, port);
 //!
 //! # Ok::<(), Box<dyn std::error::Error>>(())

--- a/src/application/command_handlers/create/mod.rs
+++ b/src/application/command_handlers/create/mod.rs
@@ -26,7 +26,8 @@
 //! use std::sync::Arc;
 //! use torrust_tracker_deployer_lib::application::command_handlers::create::CreateCommandHandler;
 //! use torrust_tracker_deployer_lib::application::command_handlers::create::config::{
-//!     EnvironmentCreationConfig, EnvironmentSection, SshCredentialsConfig
+//!     EnvironmentCreationConfig, EnvironmentSection, LxdProviderSection, ProviderSection,
+//!     SshCredentialsConfig,
 //! };
 //! use torrust_tracker_deployer_lib::infrastructure::persistence::repository_factory::RepositoryFactory;
 //! use torrust_tracker_deployer_lib::shared::{SystemClock, Clock};
@@ -43,6 +44,7 @@
 //! let config = EnvironmentCreationConfig::new(
 //!     EnvironmentSection {
 //!         name: "production".to_string(),
+//!         instance_name: None, // Auto-generate from environment name
 //!     },
 //!     SshCredentialsConfig::new(
 //!         "keys/prod_key".to_string(),
@@ -50,6 +52,9 @@
 //!         "torrust".to_string(),
 //!         22,
 //!     ),
+//!     ProviderSection::Lxd(LxdProviderSection {
+//!         profile_name: "lxd-production".to_string(),
+//!     }),
 //! );
 //!
 //! // Execute command with working directory

--- a/src/application/command_handlers/create/tests/builders.rs
+++ b/src/application/command_handlers/create/tests/builders.rs
@@ -10,7 +10,8 @@ use chrono::{DateTime, Utc};
 use tempfile::TempDir;
 
 use crate::application::command_handlers::create::config::{
-    EnvironmentCreationConfig, EnvironmentSection, SshCredentialsConfig,
+    EnvironmentCreationConfig, EnvironmentSection, LxdProviderSection, ProviderSection,
+    SshCredentialsConfig,
 };
 use crate::application::command_handlers::create::CreateCommandHandler;
 use crate::domain::environment::{Environment, EnvironmentName};
@@ -257,6 +258,7 @@ pub fn create_valid_test_config(temp_dir: &TempDir, env_name: &str) -> Environme
     EnvironmentCreationConfig::new(
         EnvironmentSection {
             name: env_name.to_string(),
+            instance_name: None, // Auto-generate from environment name
         },
         SshCredentialsConfig::new(
             private_key.to_string_lossy().to_string(),
@@ -264,6 +266,9 @@ pub fn create_valid_test_config(temp_dir: &TempDir, env_name: &str) -> Environme
             "torrust".to_string(),
             22,
         ),
+        ProviderSection::Lxd(LxdProviderSection {
+            profile_name: format!("lxd-{env_name}"),
+        }),
     )
 }
 

--- a/src/application/command_handlers/create/tests/integration.rs
+++ b/src/application/command_handlers/create/tests/integration.rs
@@ -111,7 +111,8 @@ fn it_should_persist_environment_state_to_repository() {
 #[test]
 fn it_should_fail_with_invalid_environment_name() {
     use crate::application::command_handlers::create::config::{
-        EnvironmentCreationConfig, EnvironmentSection, SshCredentialsConfig,
+        EnvironmentCreationConfig, EnvironmentSection, LxdProviderSection, ProviderSection,
+        SshCredentialsConfig,
     };
     use std::fs;
 
@@ -127,6 +128,7 @@ fn it_should_fail_with_invalid_environment_name() {
     let config = EnvironmentCreationConfig::new(
         EnvironmentSection {
             name: "Invalid_Name".to_string(), // Invalid: contains uppercase
+            instance_name: None,
         },
         SshCredentialsConfig::new(
             private_key.to_string_lossy().to_string(),
@@ -134,6 +136,9 @@ fn it_should_fail_with_invalid_environment_name() {
             "torrust".to_string(),
             22,
         ),
+        ProviderSection::Lxd(LxdProviderSection {
+            profile_name: "test-profile".to_string(),
+        }),
     );
 
     // Act
@@ -155,7 +160,8 @@ fn it_should_fail_with_invalid_environment_name() {
 #[test]
 fn it_should_fail_when_ssh_private_key_not_found() {
     use crate::application::command_handlers::create::config::{
-        EnvironmentCreationConfig, EnvironmentSection, SshCredentialsConfig,
+        EnvironmentCreationConfig, EnvironmentSection, LxdProviderSection, ProviderSection,
+        SshCredentialsConfig,
     };
 
     // Arrange
@@ -165,6 +171,7 @@ fn it_should_fail_when_ssh_private_key_not_found() {
     let config = EnvironmentCreationConfig::new(
         EnvironmentSection {
             name: "test-env".to_string(),
+            instance_name: None,
         },
         SshCredentialsConfig::new(
             "/nonexistent/private_key".to_string(),
@@ -176,6 +183,9 @@ fn it_should_fail_when_ssh_private_key_not_found() {
             "torrust".to_string(),
             22,
         ),
+        ProviderSection::Lxd(LxdProviderSection {
+            profile_name: "test-profile".to_string(),
+        }),
     );
 
     // Act

--- a/src/domain/provider/provider_type.rs
+++ b/src/domain/provider/provider_type.rs
@@ -3,6 +3,7 @@
 //! This module defines the `Provider` enum which represents the available
 //! infrastructure providers for deploying Torrust Tracker environments.
 
+use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
 /// Supported infrastructure providers
@@ -27,7 +28,7 @@ use serde::{Deserialize, Serialize};
 /// assert_eq!(provider.as_str(), "lxd");
 /// assert_eq!(provider.to_string(), "lxd");
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub enum Provider {
     /// LXD - Local development and testing

--- a/src/presentation/controllers/create/router.rs
+++ b/src/presentation/controllers/create/router.rs
@@ -41,12 +41,15 @@ pub async fn route_command(
             .await
             .map(|_| ()) // Convert Environment<Created> to ()
             .map_err(CreateCommandError::Environment),
-        CreateAction::Template { output_path } => {
+        CreateAction::Template {
+            output_path,
+            provider,
+        } => {
             let template_path = output_path.unwrap_or_else(CreateAction::default_template_path);
             context
                 .container()
                 .create_template_controller()
-                .execute(&template_path)
+                .execute(&template_path, provider)
                 .await
                 .map_err(CreateCommandError::Template)
         }

--- a/src/presentation/controllers/create/subcommands/environment/config_loader.rs
+++ b/src/presentation/controllers/create/subcommands/environment/config_loader.rs
@@ -124,6 +124,10 @@ mod tests {
             "ssh_credentials": {{
                 "private_key_path": "{private_key_path}",
                 "public_key_path": "{public_key_path}"
+            }},
+            "provider": {{
+                "provider": "lxd",
+                "profile_name": "lxd-test-env"
             }}
         }}"#
         );
@@ -209,6 +213,10 @@ mod tests {
             "ssh_credentials": {{
                 "private_key_path": "{private_key_path}",
                 "public_key_path": "{public_key_path}"
+            }},
+            "provider": {{
+                "provider": "lxd",
+                "profile_name": "lxd-test"
             }}
         }}"#
         );
@@ -239,6 +247,10 @@ mod tests {
             "ssh_credentials": {
                 "private_key_path": "/nonexistent/key",
                 "public_key_path": "/nonexistent/key.pub"
+            },
+            "provider": {
+                "provider": "lxd",
+                "profile_name": "lxd-test-env"
             }
         }"#;
         fs::write(&config_path, config_json).unwrap();
@@ -274,6 +286,10 @@ mod tests {
             "ssh_credentials": {{
                 "private_key_path": "{private_key_path}",
                 "public_key_path": "{public_key_path}"
+            }},
+            "provider": {{
+                "provider": "lxd",
+                "profile_name": "lxd-test-env"
             }}
         }}"#
         );

--- a/src/presentation/controllers/create/subcommands/environment/errors.rs
+++ b/src/presentation/controllers/create/subcommands/environment/errors.rs
@@ -195,22 +195,23 @@ For more information about configuration format, see the documentation."
    - environment.name
    - ssh_credentials.private_key_path
    - ssh_credentials.public_key_path
+   - provider.provider (\"lxd\" or \"hetzner\")
+   - provider.profile_name (for LXD)
+   - provider.api_token (for Hetzner)
 
 4. Check field types match expectations:
    - Strings must be in quotes
    - Numbers should not have quotes
    - Booleans are true/false (lowercase)
 
-Example valid configuration:
-{
-  \"environment\": {
-    \"name\": \"dev\"
-  },
-  \"ssh_credentials\": {
-    \"private_key_path\": \"fixtures/testing_rsa\",
-    \"public_key_path\": \"fixtures/testing_rsa.pub\"
-  }
-}
+5. Generate a valid configuration template:
+   # For LXD:
+   torrust-tracker-deployer create template --provider lxd ./environment.json
+
+   # For Hetzner:
+   torrust-tracker-deployer create template --provider hetzner ./environment.json
+
+   Then edit the generated file to replace placeholder values with your actual configuration.
 
 For more information, see the configuration documentation."
                 }

--- a/src/presentation/controllers/create/subcommands/environment/tests.rs
+++ b/src/presentation/controllers/create/subcommands/environment/tests.rs
@@ -38,6 +38,10 @@ async fn it_should_create_environment_from_valid_config() {
         "ssh_credentials": {{
             "private_key_path": "{private_key_path}",
             "public_key_path": "{public_key_path}"
+        }},
+        "provider": {{
+            "provider": "lxd",
+            "profile_name": "lxd-test-create-env"
         }}
     }}"#
     );
@@ -132,6 +136,10 @@ async fn it_should_return_error_for_duplicate_environment() {
         "ssh_credentials": {{
             "private_key_path": "{private_key_path}",
             "public_key_path": "{public_key_path}"
+        }},
+        "provider": {{
+            "provider": "lxd",
+            "profile_name": "lxd-duplicate-env"
         }}
     }}"#
     );
@@ -186,6 +194,10 @@ async fn it_should_create_environment_in_custom_working_dir() {
         "ssh_credentials": {{
             "private_key_path": "{private_key_path}",
             "public_key_path": "{public_key_path}"
+        }},
+        "provider": {{
+            "provider": "lxd",
+            "profile_name": "lxd-custom-location-env"
         }}
     }}"#
     );

--- a/src/presentation/controllers/create/tests/template.rs
+++ b/src/presentation/controllers/create/tests/template.rs
@@ -4,6 +4,7 @@
 //! configuration file templates with placeholder values.
 
 use crate::bootstrap::Container;
+use crate::domain::provider::Provider;
 use crate::presentation::controllers::create;
 use crate::presentation::controllers::tests::TestContext;
 use crate::presentation::dispatch::ExecutionContext;
@@ -18,7 +19,10 @@ async fn it_should_generate_template_with_default_path() {
     let original_dir = std::env::current_dir().unwrap();
     std::env::set_current_dir(test_context.working_dir()).unwrap();
 
-    let action = CreateAction::Template { output_path: None };
+    let action = CreateAction::Template {
+        output_path: None,
+        provider: Provider::Lxd,
+    };
     let container = Container::new(VerbosityLevel::Silent, test_context.working_dir());
     let context = ExecutionContext::new(std::sync::Arc::new(container));
 
@@ -63,6 +67,7 @@ async fn it_should_generate_template_with_custom_path() {
 
     let action = CreateAction::Template {
         output_path: Some(custom_path.clone()),
+        provider: Provider::Lxd,
     };
     let container = Container::new(VerbosityLevel::Silent, test_context.working_dir());
     let context = ExecutionContext::new(std::sync::Arc::new(container));
@@ -89,6 +94,7 @@ async fn it_should_generate_valid_json_template() {
 
     let action = CreateAction::Template {
         output_path: Some(template_path.clone()),
+        provider: Provider::Lxd,
     };
     let container = Container::new(VerbosityLevel::Silent, test_context.working_dir());
     let context = ExecutionContext::new(std::sync::Arc::new(container));
@@ -137,6 +143,7 @@ async fn it_should_create_parent_directories() {
 
     let action = CreateAction::Template {
         output_path: Some(deep_path.clone()),
+        provider: Provider::Lxd,
     };
     let container = Container::new(VerbosityLevel::Silent, test_context.working_dir());
     let context = ExecutionContext::new(std::sync::Arc::new(container));

--- a/src/presentation/controllers/mod.rs
+++ b/src/presentation/controllers/mod.rs
@@ -130,6 +130,7 @@
 //! **Current Implementation Example** (from `create/router.rs`):
 //! ```rust,no_run
 //! use std::path::Path;
+//! use torrust_tracker_deployer_lib::domain::provider::Provider;
 //! use torrust_tracker_deployer_lib::presentation::input::cli::commands::CreateAction;
 //! use torrust_tracker_deployer_lib::presentation::dispatch::context::ExecutionContext;
 //! use torrust_tracker_deployer_lib::presentation::controllers::create::errors::CreateCommandError;
@@ -155,12 +156,12 @@
 //!                 .map(|_| ()) // Convert Environment<Created> to ()
 //!                 .map_err(CreateCommandError::Environment)
 //!         }
-//!         CreateAction::Template { output_path } => {
+//!         CreateAction::Template { output_path, provider } => {
 //!             let template_path = output_path.unwrap_or_else(CreateAction::default_template_path);
 //!             context
 //!                 .container()
 //!                 .create_template_controller()
-//!                 .execute(&template_path)
+//!                 .execute(&template_path, provider)
 //!                 .await
 //!                 .map_err(CreateCommandError::Template)
 //!         }

--- a/src/presentation/controllers/tests/mod.rs
+++ b/src/presentation/controllers/tests/mod.rs
@@ -159,6 +159,10 @@ pub fn create_valid_config(path: &Path, env_name: &str) -> PathBuf {
     "ssh_credentials": {{
         "private_key_path": "{private_key_path}",
         "public_key_path": "{public_key_path}"
+    }},
+    "provider": {{
+        "provider": "lxd",
+        "profile_name": "lxd-{env_name}"
     }}
 }}"#
     );
@@ -248,6 +252,10 @@ pub fn create_config_with_invalid_name(path: &Path) -> PathBuf {
     "ssh_credentials": {{
         "private_key_path": "{private_key_path}",
         "public_key_path": "{public_key_path}"
+    }},
+    "provider": {{
+        "provider": "lxd",
+        "profile_name": "lxd-test"
     }}
 }}"#
     );
@@ -294,6 +302,10 @@ pub fn create_config_with_missing_keys(path: &Path) -> PathBuf {
     "ssh_credentials": {
         "private_key_path": "/nonexistent/private_key",
         "public_key_path": "/nonexistent/public_key.pub"
+    },
+    "provider": {
+        "provider": "lxd",
+        "profile_name": "lxd-test-env"
     }
 }"#;
 

--- a/src/presentation/input/cli/commands.rs
+++ b/src/presentation/input/cli/commands.rs
@@ -7,6 +7,8 @@ use clap::Subcommand;
 
 use std::path::PathBuf;
 
+use crate::domain::provider::Provider;
+
 /// Available CLI commands
 ///
 /// This enum defines all the subcommands available in the CLI application.
@@ -161,6 +163,14 @@ pub enum CreateAction {
         /// automatically if they don't exist.
         #[arg(value_name = "PATH")]
         output_path: Option<PathBuf>,
+
+        /// Provider to generate template for (required)
+        ///
+        /// Available providers:
+        /// - lxd: Local LXD provider for development and testing
+        /// - hetzner: Hetzner Cloud provider for production deployments
+        #[arg(long, short = 'p', value_enum)]
+        provider: Provider,
     },
 }
 

--- a/src/testing/e2e/tasks/black_box/generate_config.rs
+++ b/src/testing/e2e/tasks/black_box/generate_config.rs
@@ -115,11 +115,18 @@ pub fn generate_environment_config_with_port(
         ssh_credentials["port"] = serde_json::json!(port);
     }
 
+    // Create provider configuration with profile name based on environment name
+    let provider = serde_json::json!({
+        "provider": "lxd",
+        "profile_name": format!("torrust-profile-{}", environment_name)
+    });
+
     let config = serde_json::json!({
         "environment": {
             "name": environment_name
         },
-        "ssh_credentials": ssh_credentials
+        "ssh_credentials": ssh_credentials,
+        "provider": provider
     });
 
     // Write to envs directory

--- a/src/testing/e2e/tasks/run_create_command.rs
+++ b/src/testing/e2e/tasks/run_create_command.rs
@@ -22,7 +22,8 @@ use thiserror::Error;
 use tracing::info;
 
 use crate::application::command_handlers::create::config::{
-    EnvironmentCreationConfig, EnvironmentSection, SshCredentialsConfig,
+    EnvironmentCreationConfig, EnvironmentSection, LxdProviderSection, ProviderSection,
+    SshCredentialsConfig,
 };
 use crate::application::command_handlers::create::{
     CreateCommandHandler, CreateCommandHandlerError,
@@ -82,10 +83,11 @@ pub fn run_create_command(
     // Create the command handler
     let create_command = CreateCommandHandler::new(repository, clock);
 
-    // Build the configuration
+    // Build the configuration with LXD provider
     let config = EnvironmentCreationConfig::new(
         EnvironmentSection {
             name: environment_name.to_string(),
+            instance_name: None, // Auto-generate from environment name
         },
         SshCredentialsConfig::new(
             ssh_private_key_path,
@@ -93,6 +95,9 @@ pub fn run_create_command(
             ssh_username.to_string(),
             ssh_port,
         ),
+        ProviderSection::Lxd(LxdProviderSection {
+            profile_name: format!("lxd-{environment_name}"),
+        }),
     );
 
     // Execute the command

--- a/tests/e2e_create_command.rs
+++ b/tests/e2e_create_command.rs
@@ -208,6 +208,10 @@ fn create_test_environment_config(env_name: &str) -> String {
         "ssh_credentials": {
             "private_key_path": private_key_path,
             "public_key_path": public_key_path
+        },
+        "provider": {
+            "provider": "lxd",
+            "profile_name": format!("lxd-{}", env_name)
         }
     })
     .to_string()

--- a/tests/e2e_destroy_command.rs
+++ b/tests/e2e_destroy_command.rs
@@ -66,6 +66,10 @@ fn create_test_environment_config(env_name: &str) -> String {
             "public_key_path": public_key_path,
             "username": "torrust",
             "port": 22
+        },
+        "provider": {
+            "provider": "lxd",
+            "profile_name": format!("lxd-{}", env_name)
         }
     })
     .to_string()


### PR DESCRIPTION
## Summary

This PR implements issue #208 from the Hetzner Provider Support epic (#205).

## Changes

### Core Configuration Updates
- Add `provider` field to `EnvironmentCreationConfig` (uses `ProviderSection` for JSON parsing)
- Add `instance_name` optional field to `EnvironmentSection` (auto-generated as `torrust-tracker-vm-{env_name}` if not provided)
- Update `to_environment_params()` to return `(EnvironmentName, InstanceName, ProviderConfig, SshCredentials, port)`

### Error Handling
- Add `InvalidInstanceName` error variant with actionable help message

### CLI Updates
- Add `clap::ValueEnum` derive to `Provider` enum for CLI argument parsing
- Add `--provider`/`-p` **required** argument to `create template` command
- Generate provider-specific templates:
  - **LXD**: Includes `profile_name` placeholder
  - **Hetzner**: Includes `api_token`, `server_type`, `location` placeholders

### Documentation
- Update `docs/user-guide/commands/create.md` with new configuration format
- Update help messages to show both LXD and Hetzner template generation commands

### Tests
- Update all tests to include provider configuration in JSON fixtures

## Breaking Changes

⚠️ **Environment JSON files now require a `provider` section**

⚠️ **`create template` command now requires `--provider` argument**

## Example Configurations

### LXD Provider
```json
{
  "environment": {
    "name": "dev",
    "instance_name": "torrust-tracker-vm-dev"
  },
  "ssh_credentials": {
    "private_key_path": "fixtures/testing_rsa",
    "public_key_path": "fixtures/testing_rsa.pub",
    "username": "torrust",
    "port": 22
  },
  "provider": {
    "provider": "lxd",
    "profile_name": "torrust-profile-dev"
  }
}
```

### Hetzner Provider
```json
{
  "environment": {
    "name": "prod",
    "instance_name": "torrust-tracker-demo"
  },
  "ssh_credentials": {
    "private_key_path": "~/.ssh/id_rsa",
    "public_key_path": "~/.ssh/id_rsa.pub",
    "username": "torrust",
    "port": 22
  },
  "provider": {
    "provider": "hetzner",
    "api_token": "your-hetzner-api-token",
    "server_type": "cx22",
    "location": "nbg1"
  }
}
```

## Testing

- [x] All 1228 library tests pass
- [x] All 300 doc tests pass
- [x] E2E provision and destroy tests pass
- [x] E2E configuration tests pass
- [x] E2E full test passes
- [x] Pre-commit checks pass

## Related Issues

- Closes #208
- Part of Epic #205 (Add Hetzner Provider Support)
- Depends on #206 (Add Provider enum and ProviderConfig types)