### PR TITLE
chore: update major version dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ tokio = { version = "1.0", features = [ "full" ] }
 anyhow = "1.0"
 chrono = { version = "0.4", features = [ "serde" ] }
 clap = { version = "4.0", features = [ "derive" ] }
-derive_more = "0.99"
+derive_more = { version = "2.1", features = [ "display", "from" ] }
 figment = { version = "0.10", features = [ "json" ] }
 parking_lot = "0.12"
 reqwest = "0.12"

--- a/src/infrastructure/templating/ansible/template/wrappers/inventory/context/ansible_host.rs
+++ b/src/infrastructure/templating/ansible/template/wrappers/inventory/context/ansible_host.rs
@@ -24,7 +24,7 @@ pub enum AnsibleHostError {
 ///
 /// For this implementation, we only support IP addresses (IPv4 and IPv6) for simplicity.
 #[derive(Debug, Clone, PartialEq, Eq, Display, From, Serialize)]
-#[display(fmt = "{ip}")]
+#[display("{ip}")]
 #[serde(transparent)]
 pub struct AnsibleHost {
     ip: IpAddr,

--- a/src/infrastructure/templating/ansible/template/wrappers/inventory/context/ansible_port.rs
+++ b/src/infrastructure/templating/ansible/template/wrappers/inventory/context/ansible_port.rs
@@ -20,7 +20,7 @@ pub enum AnsiblePortError {
 /// Ansible's `ansible_port` represents the SSH port to connect to.
 /// Valid port numbers are in the range 1-65535.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Display, From, Serialize)]
-#[display(fmt = "{port}")]
+#[display("{port}")]
 #[serde(transparent)]
 pub struct AnsiblePort {
     port: u16,

--- a/src/infrastructure/templating/ansible/template/wrappers/inventory/context/ssh_private_key_file.rs
+++ b/src/infrastructure/templating/ansible/template/wrappers/inventory/context/ssh_private_key_file.rs
@@ -17,7 +17,7 @@ pub enum SshPrivateKeyFileError {
 
 /// Wrapper type for SSH private key file path using the newtype pattern
 #[derive(Debug, Clone, PartialEq, Eq, Display, From, Serialize)]
-#[display(fmt = "{}", "path.display()")]
+#[display("{}", path.display())]
 #[serde(transparent)]
 pub struct SshPrivateKeyFile {
     path: PathBuf,


### PR DESCRIPTION
This PR updates the following major version dependencies:

- testcontainers: 0.25 → 0.26
- thiserror: 1.0 → 2.0
- rstest: 0.23 → 0.26
- derive_more: 0.99 → 2.1

Each dependency was updated incrementally with pre-commit checks passing after each update.

## Changes

### derive_more 2.1

- Added explicit features: `display` and `from`
- Updated Display macro syntax (removed `fmt =` prefix) in:
  - `ansible_host.rs`
  - `ansible_port.rs`
  - `ssh_private_key_file.rs`

All tests (1447 unit tests, 368 doc tests, E2E tests) pass successfully.