### PR TITLE
docs: [#262] Document environment configuration DTOs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,8 @@ These principles should guide all development decisions, code reviews, and featu
 
 18. **When handling sensitive data (secrets)** (CRITICAL for security): Read [`docs/contributing/secret-handling.md`](docs/contributing/secret-handling.md) for the complete guide. **NEVER use `String` for sensitive data like API tokens, passwords, private keys, or database credentials**. Always use wrapper types from `src/shared/secrets/`: `ApiToken` for API tokens, `Password` for passwords, and their plain type aliases (`PlainApiToken`/`PlainPassword`) at DTO boundaries. Call `.expose_secret()` only when the actual value is needed. See the [ADR](docs/decisions/secrecy-crate-for-sensitive-data.md) for architectural rationale.
 
+19. **When generating environment configurations** (for AI agents): Reference the Rust types in [`src/application/command_handlers/create/config/`](src/application/command_handlers/create/config/) for accurate constraint information. These types express richer validation rules than the JSON schema alone (e.g., `NonZeroU32`, tagged enums, newtype wrappers). Read the [README](src/application/command_handlers/create/config/README.md) in that folder for the full guide. The JSON schema (`schemas/environment-config.json`) provides basic structure, but the Rust types are authoritative for constraints. See the [ADR](docs/decisions/configuration-dto-layer-placement.md) for why these types are in the application layer.
+
 ## 🧪 Build & Test
 
 - **Setup Dependencies**: `cargo run --bin dependency-installer install` (sets up required development tools)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -6,6 +6,7 @@ This directory contains architectural decision records for the Torrust Tracker D
 
 | Status        | Date       | Decision                                                                                                  | Summary                                                                                    |
 | ------------- | ---------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| ✅ Accepted   | 2026-01-07 | [Configuration DTO Layer Placement](./configuration-dto-layer-placement.md)                               | Keep configuration DTOs in application layer, not domain; defer package extraction         |
 | ✅ Accepted   | 2025-12-23 | [Docker Security Scan Exit Code Zero](./docker-security-scan-exit-code-zero.md)                           | Use exit-code 0 for security scanning - Trivy detects, GitHub Security decides, CI green   |
 | ✅ Accepted   | 2025-12-20 | [Grafana Integration Pattern](./grafana-integration-pattern.md)                                           | Enable Grafana by default with hard Prometheus dependency and environment variable config  |
 | ✅ Accepted   | 2025-12-17 | [Secrecy Crate for Sensitive Data Handling](./secrecy-crate-for-sensitive-data.md)                        | Use secrecy crate for type-safe secret handling with memory zeroing                        |

--- a/docs/decisions/configuration-dto-layer-placement.md
+++ b/docs/decisions/configuration-dto-layer-placement.md
@@ -1,0 +1,107 @@
+# Decision: Configuration DTO Layer Placement
+
+## Status
+
+Accepted
+
+## Date
+
+2026-01-09
+
+## Context
+
+The project has configuration types for environment creation that sit at the boundary between external configuration sources (JSON files, CLI arguments) and the internal domain model. These types:
+
+1. **Deserialize from JSON** - Accept user input with raw primitives (`String`, `u32`)
+2. **Validate and convert** - Transform to strongly-typed domain objects via `to_*_config()` methods
+3. **Generate JSON Schema** - Derive `JsonSchema` for IDE autocomplete
+
+The question arose: where should these types live in the DDD architecture?
+
+**Options considered:**
+
+1. **Domain layer** (`src/domain/`) - Where business entities live
+2. **Application layer** (`src/application/`) - Where use cases and commands live
+3. **Separate workspace package** - For reuse by other applications
+
+Additionally, AI agents need to reference these types to generate accurate configurations, as Rust types express constraints that JSON Schema cannot fully capture (e.g., `NonZeroU32`, tagged enums, custom validation logic).
+
+## Decision
+
+**Keep configuration DTOs in `src/application/command_handlers/create/config/`** (application layer).
+
+**Do not extract to a separate package** at this time.
+
+### Rationale for Application Layer
+
+1. **DTOs are not domain concepts** - They represent input formats, not business entities. The domain layer should contain semantic business concepts like `Environment`, `TrackerConfig`, not parsing concerns.
+
+2. **Unidirectional dependency** - Config DTOs import domain types to convert to (`DTO → Domain`). This is correct: application layer depends on domain, not vice versa.
+
+3. **Serialization is application concern** - Heavy `serde` usage (`Deserialize`, `Serialize`, `JsonSchema`) belongs at application boundaries, not in the domain core.
+
+4. **Command-specific** - These types are specific to the `create` command. Other commands may have different configuration needs.
+
+5. **Follows Anti-Corruption Layer pattern** - The config types protect the domain from external JSON format changes.
+
+### Rationale Against Separate Package (Now)
+
+1. **No immediate consumers** - No other Rust applications currently need these types
+2. **Versioning overhead** - Separate packages require versioning discipline
+3. **Premature abstraction** - YAGNI (You Aren't Gonna Need It)
+4. **Types are well-organized** - Already isolated in a submodule, easy to extract later
+
+## Consequences
+
+### Positive
+
+- **Clear architectural boundaries** - DTOs vs domain types are distinct
+- **AI agents can reference types** - Folder path documented in `AGENTS.md` rule 19
+- **No versioning complexity** - Single crate, simple dependency management
+- **Future-ready** - Types are organized for potential extraction
+
+### Negative
+
+- **Cannot reuse from external Rust apps** - Must copy types or depend on entire crate
+- **AI agents need to read Rust code** - JSON schema alone is insufficient for full constraints
+
+### Risks
+
+- If multiple applications need these types, extraction becomes necessary
+- Changes to domain types may require updates to DTOs (but this is expected)
+
+## Alternatives Considered
+
+### 1. Domain Layer Placement
+
+**Rejected because:**
+
+- Domain types should represent business concepts, not input formats
+- Would pollute domain with serialization concerns
+- Domain already has clean types (`TrackerConfig`, `GrafanaConfig`)
+
+### 2. Separate Workspace Package
+
+**Deferred because:**
+
+- No current consumers
+- Adds versioning complexity
+- Can be done later if needed (types are already isolated)
+
+### 3. Infrastructure Layer
+
+**Rejected because:**
+
+- Config parsing is not external system integration
+- Would mix concerns with SSH, Ansible, OpenTofu adapters
+
+## Related Decisions
+
+- [Secrecy Crate for Sensitive Data](./secrecy-crate-for-sensitive-data.md) - How secrets are handled in DTOs vs domain
+- [DDD Layer Placement Guide](../contributing/ddd-layer-placement.md) - General guidance for layer decisions
+
+## References
+
+- [Anti-Corruption Layer pattern](https://docs.microsoft.com/en-us/azure/architecture/patterns/anti-corruption-layer) - Microsoft patterns documentation
+- [Config README](../../src/application/command_handlers/create/config/README.md) - Detailed documentation for AI agents
+- [JSON Schema](../../schemas/README.md) - Generated schema for IDE autocomplete

--- a/src/application/command_handlers/create/config/README.md
+++ b/src/application/command_handlers/create/config/README.md
@@ -1,0 +1,97 @@
+# Environment Configuration DTOs
+
+This module contains **Configuration Data Transfer Objects (DTOs)** for environment creation. These types sit at the boundary between external configuration sources (JSON files, CLI arguments) and the internal domain model.
+
+## Purpose
+
+These types serve multiple purposes:
+
+1. **JSON Deserialization** - Accept user input from configuration files
+2. **Validation Gateway** - Convert loose string-based input to strict domain types
+3. **Schema Generation** - Derive `JsonSchema` for IDE autocomplete (see `schemas/environment-config.json`)
+4. **AI Agent Reference** - Provide richer type information than JSON schema alone
+
+## Architecture Pattern
+
+This module implements the **Anti-Corruption Layer** pattern from Domain-Driven Design:
+
+```text
+User JSON → [Config DTOs] → validate/transform → [Domain Types]
+             (String-based)                       (PathBuf, NonZeroU32, etc.)
+```
+
+### Key Differences from Domain Types
+
+| Aspect         | Config DTOs (this module)                        | Domain Types                                     |
+| -------------- | ------------------------------------------------ | ------------------------------------------------ |
+| **Layer**      | Application                                      | Domain                                           |
+| **Purpose**    | JSON parsing                                     | Business logic                                   |
+| **Types**      | Raw primitives (`String`, `u32`)                 | Validated newtypes (`NonZeroU32`, `ProfileName`) |
+| **Validation** | Deferred to `to_*_config()`                      | Enforced at construction                         |
+| **Serde**      | Heavy (`Deserialize`, `Serialize`, `JsonSchema`) | Minimal                                          |
+
+## Module Structure
+
+```text
+config/
+├── environment_config.rs    # EnvironmentCreationConfig (top-level)
+├── ssh_credentials_config.rs # SshCredentialsConfig
+├── prometheus.rs            # PrometheusSection
+├── grafana.rs               # GrafanaSection
+├── errors.rs                # CreateConfigError
+├── provider/
+│   ├── lxd.rs               # LxdProviderSection
+│   └── hetzner.rs           # HetznerProviderSection
+└── tracker/
+    ├── tracker_section.rs       # TrackerSection (aggregate)
+    ├── tracker_core_section.rs  # TrackerCoreSection, DatabaseSection
+    ├── udp_tracker_section.rs   # UdpTrackerSection
+    ├── http_tracker_section.rs  # HttpTrackerSection
+    ├── http_api_section.rs      # HttpApiSection
+    └── health_check_api_section.rs # HealthCheckApiSection
+```
+
+## Conversion Pattern
+
+Each DTO provides a `to_*_config()` method that validates and converts to domain types:
+
+```rust
+// Example: PrometheusSection → PrometheusConfig
+impl PrometheusSection {
+    pub fn to_prometheus_config(&self) -> Result<PrometheusConfig, CreateConfigError> {
+        // Validates: scrape_interval must be > 0
+        let interval = NonZeroU32::new(self.scrape_interval_in_secs)
+            .ok_or_else(|| CreateConfigError::InvalidPrometheusConfig(...))?;
+        Ok(PrometheusConfig::new(interval))
+    }
+}
+```
+
+## Constraints Expressed in Rust (Not in JSON Schema)
+
+The Rust types express constraints that JSON Schema cannot fully capture:
+
+| Constraint                 | Rust Type                                   | JSON Schema Limitation             |
+| -------------------------- | ------------------------------------------- | ---------------------------------- |
+| Non-zero integers          | `NonZeroU32`                                | Can only specify `minimum: 1`      |
+| Mutually exclusive options | Tagged enums with `#[serde(tag = "...")]`   | `oneOf` is complex and error-prone |
+| Path validation            | `PathBuf` with existence checks             | No file system awareness           |
+| Format validation          | Newtype constructors (`ProfileName::new()`) | Regex patterns are limited         |
+| Cross-field validation     | Custom `to_*_config()` logic                | No support                         |
+| Secret handling            | `Password`, `ApiToken` wrappers             | No security semantics              |
+
+## For AI Agents
+
+When generating environment configuration:
+
+1. **Reference these Rust types** for accurate constraint information
+2. **Follow the structure** in `EnvironmentCreationConfig` as the root type
+3. **Check validation logic** in `to_*_config()` methods for business rules
+4. **Use JSON schema** (`schemas/environment-config.json`) for basic structure, but trust Rust types for constraints
+
+## Related Documentation
+
+- [JSON Schema](../../../../schemas/README.md) - Generated schema for IDE autocomplete
+- [JSON Schema IDE Setup](../../../../docs/user-guide/json-schema-ide-setup.md) - Configure VS Code/editors
+- [ADR: Configuration DTO Layer Placement](../../../../docs/decisions/configuration-dto-layer-placement.md) - Why these types are in application layer
+- [DDD Layer Placement Guide](../../../../docs/contributing/ddd-layer-placement.md) - General layer placement guidance


### PR DESCRIPTION
## Summary

Documents the architectural decision to keep configuration DTOs in the application layer and provides guidance for AI agents on how to reference these types for accurate configuration generation.

Closes #262

## Changes

- **ADR**: Added `docs/decisions/configuration-dto-layer-placement.md` explaining why config DTOs belong in the application layer (not domain or separate package)
- **Config README**: Added `src/application/command_handlers/create/config/README.md` with detailed documentation for AI agents
- **AGENTS.md**: Added rule 19 pointing to config types as the authoritative source for constraint information
- **ADR Index**: Updated `docs/decisions/README.md` with the new decision

## Rationale

The configuration DTOs serve as an Anti-Corruption Layer between external JSON input and internal domain types. They:

1. **Deserialize from JSON** with raw primitives (`String`, `u32`)
2. **Validate and convert** to strongly-typed domain objects via `to_*_config()` methods
3. **Generate JSON Schema** for IDE autocomplete

These are **application layer concerns**, not domain concepts, because:
- They represent input formats, not business entities
- Heavy `serde` usage belongs at application boundaries
- They're specific to the `create` command

## For AI Agents

The new documentation helps AI agents generate accurate configurations by:
- Referencing Rust types that express constraints JSON Schema cannot (e.g., `NonZeroU32`, tagged enums)
- Understanding the validation logic in `to_*_config()` methods
- Following the module structure in `EnvironmentCreationConfig`

## Testing

- All linting checks pass
- All unit tests pass
- All E2E tests pass
- Documentation builds successfully