### PR TITLE
feat: [#275] Change Grafana default port from 3100 to 3000

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -6,6 +6,7 @@ This directory contains architectural decision records for the Torrust Tracker D
 
 | Status        | Date       | Decision                                                                                                  | Summary                                                                                    |
 | ------------- | ---------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| ✅ Accepted   | 2026-01-20 | [Grafana Default Port 3000](./grafana-default-port-3000.md)                                               | Use Grafana's default port 3000 instead of 3100 for dedicated VM deployments               |
 | ✅ Accepted   | 2026-01-20 | [Caddy for TLS Termination](./caddy-for-tls-termination.md)                                               | Use Caddy v2.10 as TLS proxy for automatic HTTPS with WebSocket support                    |
 | ✅ Accepted   | 2026-01-20 | [Per-Service TLS Configuration](./per-service-tls-configuration.md)                                       | Use domain + use_tls_proxy fields instead of nested tls section for explicit TLS opt-in    |
 | ✅ Accepted   | 2026-01-20 | [Uniform HTTP Tracker TLS Requirement](./uniform-http-tracker-tls-requirement.md)                         | All HTTP trackers must use same TLS setting due to tracker's global on_reverse_proxy       |

--- a/docs/decisions/docker-ufw-firewall-security-strategy.md
+++ b/docs/decisions/docker-ufw-firewall-security-strategy.md
@@ -87,7 +87,7 @@ tracker:
 
 grafana:
   ports:
-    - "3100:3000" # Grafana UI - public
+    - "3000:3000" # Grafana UI - public
 
 # Host-accessible services - bind to localhost only
 prometheus:
@@ -407,19 +407,16 @@ Docker's built-in security features we rely on:
 **Test Strategy**:
 
 1. **External Port Scanning**:
-
    - Use `nmap` or `netstat` from external host to scan VM's public IP
    - Verify ONLY expected ports are open (SSH, tracker UDP/HTTP, Grafana)
    - Verify internal service ports (Prometheus 9090, MySQL 3306) are NOT accessible
 
 2. **Docker Network Inspection**:
-
    - Query `docker port <container>` to list published ports
    - Parse `docker inspect` output to verify port bindings match specification
    - Fail if any internal service has unexpected `HostPort` mapping
 
 3. **Service Accessibility Tests**:
-
    - **From external host**: Verify public services respond (tracker, Grafana)
    - **From external host**: Verify internal services timeout/refuse (Prometheus, MySQL)
    - **From Docker host**: Verify localhost bindings work (`curl 127.0.0.1:9090` succeeds)
@@ -447,7 +444,7 @@ fn it_should_block_external_access_to_prometheus_when_deployed() {
 fn it_should_allow_external_access_to_grafana_when_deployed() {
     // 1. Deploy environment with Grafana
     // 2. Get VM public IP and configured Grafana port
-    // 3. Connect to http://<vm-ip>:3100
+    // 3. Connect to http://<vm-ip>:3000
     // 4. Assert successful connection and Grafana login page
 }
 
@@ -548,26 +545,22 @@ This section addresses critical security questions about the chosen approach.
 **✅ Meets Best Practices**:
 
 1. **Defense in Depth**:
-
    - UFW firewall (host level)
    - Docker port bindings (service level)
    - Docker network segmentation (lateral movement prevention)
    - Application authentication (Grafana, Tracker API)
 
 2. **Principle of Least Privilege**:
-
    - Services only have network access to what they need
    - Non-root container users
    - Minimal capabilities
 
 3. **Security by Default**:
-
    - Internal services not exposed (MySQL, Prometheus)
    - Public services explicitly configured
    - Localhost-only bindings for debugging services
 
 4. **Auditability**:
-
    - Explicit port bindings documented
    - Network topology documented in templates
    - Security decisions documented in ADR
@@ -607,7 +600,7 @@ This section addresses critical security questions about the chosen approach.
    fn it_should_detect_unexpected_port_exposure() {
        // Run nmap scan from external host
        // Parse open ports
-       // Assert only expected ports open (22, 6969, 7070, 1212, 3100)
+       // Assert only expected ports open (22, 6969, 7070, 1212, 3000)
        // Fail if MySQL (3306) or Prometheus (9090) detected
    }
    ```
@@ -618,7 +611,7 @@ This section addresses critical security questions about the chosen approach.
    #!/bin/bash
    # scripts/check-port-exposure.sh
 
-   EXPECTED_PORTS="22,6969,7070,1212,3100"
+   EXPECTED_PORTS="22,6969,7070,1212,3000"
    FORBIDDEN_PORTS="3306,9090"
 
    # Check docker ps for published ports
@@ -651,7 +644,7 @@ This section addresses critical security questions about the chosen approach.
    # 6969 (UDP tracker)
    # 7070 (HTTP tracker)
    # 1212 (REST API)
-   # 3100 (Grafana)
+   # 3000 (Grafana)
 
    # Unexpected = security issue
    ```

--- a/docs/decisions/grafana-default-port-3000.md
+++ b/docs/decisions/grafana-default-port-3000.md
@@ -1,0 +1,100 @@
+# Decision: Use Grafana's Default Port 3000 Instead of 3100
+
+## Status
+
+Accepted
+
+## Date
+
+2026-01-20
+
+## Context
+
+The Grafana service configuration was originally copied from the [Torrust Demo project](https://github.com/torrust/torrust-demo), which uses port 3100 on the host to avoid conflicts with other services commonly using port 3000 (like Node.js development servers that typically run on port 3000).
+
+In the Torrust Demo environment, this port offset was necessary because:
+
+- The demo runs multiple services that might conflict with development tools
+- Users often have Node.js applications running on port 3000
+- The demo is frequently run on developer machines with other services active
+
+However, in the Torrust Tracker Deployer context:
+
+- Deployments target dedicated VM instances, not developer machines
+- No other services in our stack use port 3000
+- Users expect Grafana to be on its default port
+- The port offset (3100 vs 3000) causes confusion when consulting Grafana documentation
+
+## Decision
+
+Change the Grafana host port from `3100` to `3000`, matching Grafana's internal default port.
+
+**Before:**
+
+```yaml
+grafana:
+  ports:
+    - "3100:3000" # Host:Container
+```
+
+**After:**
+
+```yaml
+grafana:
+  ports:
+    - "3000:3000" # Host:Container (using Grafana's default port)
+```
+
+## Rationale
+
+1. **Simplicity**: Using `3000:3000` is more intuitive than `3100:3000` - host and container ports match
+2. **No Conflict**: In our deployment context (dedicated VMs), there's no service using port 3000
+3. **Documentation Alignment**: Grafana's official documentation uses port 3000; matching this reduces confusion
+4. **User Expectations**: Users familiar with Grafana expect it on port 3000
+5. **Reduced Cognitive Load**: One less port mapping to remember
+
+## Consequences
+
+### Positive
+
+- More intuitive port configuration (same port inside and outside container)
+- Better alignment with Grafana's official documentation
+- Simpler mental model for users
+- Consistent with how most Grafana installations are configured
+
+### Negative
+
+- **Breaking Change for Existing Deployments**: Users with existing deployments using port 3100 will need to update their bookmarks, scripts, and firewall rules
+- **Migration Required**: Existing environments need to be re-released to apply the new port configuration
+
+### Migration Path
+
+For existing deployments:
+
+1. Run `release <environment>` to regenerate docker-compose files with new port
+2. Run `run <environment>` to restart services with new configuration
+3. Update any bookmarks, scripts, or monitoring that reference port 3100
+
+## Alternatives Considered
+
+### Keep Port 3100
+
+**Pros**: No breaking change for existing users
+
+**Cons**: Perpetuates unnecessary complexity inherited from a different project context
+
+**Decision**: Rejected - the benefits of using the default port outweigh the one-time migration cost
+
+### Make Port Configurable
+
+**Pros**: Maximum flexibility
+
+**Cons**: Adds configuration complexity for a setting rarely needed; violates "convention over configuration" principle
+
+**Decision**: Rejected - not worth the added complexity; users with special needs can fork/modify
+
+## Related
+
+- [Issue #275](https://github.com/torrust/torrust-tracker-deployer/issues/275) - Implementation tracking
+- [ADR: Grafana Integration Pattern](grafana-integration-pattern.md) - Original Grafana integration decision
+- [Torrust Demo](https://github.com/torrust/torrust-demo) - Original source of the 3100 port choice

--- a/docs/decisions/grafana-integration-pattern.md
+++ b/docs/decisions/grafana-integration-pattern.md
@@ -143,7 +143,7 @@ volumes:
 
 ### 4. External Port Exposure for UI Access
 
-Grafana UI is exposed on host port 3100 for external access.
+Grafana UI is exposed on host port 3000 for external access (same as internal port).
 
 **Implementation**:
 
@@ -151,15 +151,15 @@ Grafana UI is exposed on host port 3100 for external access.
 services:
   grafana:
     ports:
-      - "3100:3000" # Host:Container
+      - "3000:3000" # Host:Container (using Grafana's default port)
 ```
 
-**Port Choice**: 3100 on host to avoid conflicts with common port 3000 usage (Node.js dev servers, other services).
+**Port Choice**: 3000 on both host and container, matching Grafana's default port for simplicity.
 
 **Security Considerations**:
 
 - **Docker Bypasses UFW**: Published ports bypass firewall rules entirely (see [DRAFT-docker-ufw-firewall-security-strategy.md](../issues/DRAFT-docker-ufw-firewall-security-strategy.md))
-- **Current Exposure**: Port 3100 accessible from any network that can reach the host
+- **Current Exposure**: Port 3000 accessible from any network that can reach the host
 - **Acceptable for MVP**: Public exposure acceptable for development/testing environments
 - **Future Security**: Reverse proxy with TLS termination (roadmap task 6)
 
@@ -167,7 +167,7 @@ services:
 
 - Users need web UI access from their local machines
 - Simple port mapping for MVP (no reverse proxy complexity)
-- Port 3100 avoids common conflicts
+- Using default port 3000 is more intuitive and expected
 - Security tradeoffs documented and deferred to reverse proxy implementation
 
 ### 5. Service Dependencies in Docker Compose
@@ -276,25 +276,21 @@ Initial implementation does **not** auto-provision Prometheus datasource or impo
 ### Positive
 
 1. **Complete Monitoring Stack Out-of-the-Box**:
-
    - Users get metrics collection (Prometheus) + visualization (Grafana) by default
    - Production-ready monitoring without manual setup
    - Consistent with infrastructure best practices
 
 2. **Clear Dependency Management**:
-
    - Validation enforces Grafana-Prometheus dependency at creation time
    - Helpful error messages guide users to fix configuration
    - Prevents invalid configurations before deployment
 
 3. **Consistent Configuration Pattern**:
-
    - All services use environment variable injection pattern
    - Predictable structure for users and maintainers
    - Easy to add future services (Alertmanager, Loki)
 
 4. **Simple Storage Management**:
-
    - Named volume managed by Docker (no permission issues)
    - Persistent across container restarts
    - Standard Grafana practice
@@ -307,7 +303,6 @@ Initial implementation does **not** auto-provision Prometheus datasource or impo
 ### Negative
 
 1. **Manual Initial Setup Required**:
-
    - Users must add Prometheus datasource manually
    - Users must import/create dashboards manually
    - Extra steps before visualization works
@@ -315,22 +310,19 @@ Initial implementation does **not** auto-provision Prometheus datasource or impo
    - **Future**: Automation planned in follow-up issue
 
 2. **Port Exposure Security Concerns**:
-
-   - Port 3100 publicly accessible (Docker bypasses UFW)
+   - Port 3000 publicly accessible (Docker bypasses UFW)
    - No authentication beyond Grafana login (no TLS)
    - Potential security risk for production deployments
    - **Mitigation**: Documented security implications and limitations
    - **Future**: Reverse proxy with TLS (roadmap task 6)
 
 3. **Hard Prometheus Dependency**:
-
    - Grafana cannot be enabled without Prometheus
    - Limits flexibility for users with alternative data sources
    - **Mitigation**: Prometheus is the natural choice for tracker metrics
    - **Acceptable**: Hard dependency makes sense for this use case
 
 4. **Default Resource Overhead**:
-
    - Grafana container included by default increases memory/disk usage
    - Users who don't want visualization must manually remove section
    - **Mitigation**: Simple opt-out (remove config section)
@@ -345,14 +337,12 @@ Initial implementation does **not** auto-provision Prometheus datasource or impo
 ### Implementation Maintenance
 
 1. **Template Consistency**:
-
    - Conditional Grafana service in docker-compose.yml.tera
    - Conditional environment variables in .env.tera
    - Conditional volume declaration
    - Must be kept in sync with environment state
 
 2. **Validation Logic**:
-
    - Dependency validation called during environment creation
    - Error messages must remain clear and actionable
    - Unit tests cover all validation scenarios
@@ -367,13 +357,11 @@ Initial implementation does **not** auto-provision Prometheus datasource or impo
 **Planned Automation** (separate issue):
 
 1. **Auto-Provision Prometheus Datasource**:
-
    - Create `provisioning/datasources/prometheus.yml` during release
    - Grafana automatically connects to Prometheus on startup
    - Zero-config experience for users
 
 2. **Auto-Import Tracker Dashboards**:
-
    - Copy `stats.json` and `metrics.json` from torrust-demo
    - Create `provisioning/dashboards/` directory during release
    - Dashboards available immediately after deployment

--- a/docs/e2e-testing/manual/grafana-verification.md
+++ b/docs/e2e-testing/manual/grafana-verification.md
@@ -85,7 +85,7 @@ f0e3124878de   torrust/tracker:develop    "/usr/local/bin/entr…"   Up 2 minute
 
 - ✅ `grafana/grafana:11.4.0` container is present
 - ✅ Container status shows "Up" (not "Restarting" or "Exited")
-- ✅ Port 3100 is exposed (`0.0.0.0:3100->3000/tcp`)
+- ✅ Port 3000 is exposed (`0.0.0.0:3000->3000/tcp`)
 
 ### 2. Verify Grafana Web Interface is Accessible
 
@@ -93,7 +93,7 @@ Test that you can access the Grafana web interface from your local machine:
 
 ```bash
 # Test HTTP response (should get redirect to login page)
-curl -v http://<VM_IP>:3100/
+curl -v http://<VM_IP>:3000/
 ```
 
 **Expected output:**
@@ -110,7 +110,7 @@ This confirms Grafana is running and accessible. The 302 redirect is expected - 
 Open your web browser and navigate to:
 
 ```text
-http://<VM_IP>:3100/
+http://<VM_IP>:3000/
 ```
 
 You should see the Grafana login page.
@@ -127,7 +127,7 @@ Test that you can authenticate with the credentials from your environment config
 
 ```bash
 # Test with your configured credentials
-curl -u admin:SecurePassword123! http://<VM_IP>:3100/api/datasources
+curl -u admin:SecurePassword123! http://<VM_IP>:3000/api/datasources
 ```
 
 **Expected output:**
@@ -142,7 +142,7 @@ An empty array indicates successful authentication (no datasources configured ye
 
 ```bash
 # This should fail
-curl -u admin:wrongpassword http://<VM_IP>:3100/api/datasources
+curl -u admin:wrongpassword http://<VM_IP>:3000/api/datasources
 ```
 
 **Expected output:**
@@ -286,7 +286,7 @@ Check the Prometheus datasource configuration via Grafana API:
 
 ```bash
 # List configured datasources
-curl -u admin:SecurePassword123! http://<VM_IP>:3100/api/datasources
+curl -u admin:SecurePassword123! http://<VM_IP>:3000/api/datasources
 ```
 
 **Expected output:**
@@ -334,7 +334,7 @@ Test that Grafana can successfully query metrics from Prometheus:
 ```bash
 # Test datasource health check
 curl -u admin:SecurePassword123! \
-  "http://<VM_IP>:3100/api/datasources/proxy/1/api/v1/query?query=up"
+  "http://<VM_IP>:3000/api/datasources/proxy/1/api/v1/query?query=up"
 ```
 
 **Expected output:**
@@ -371,7 +371,7 @@ curl -u admin:SecurePassword123! \
 ```bash
 # Query total announces
 curl -u admin:SecurePassword123! \
-  "http://<VM_IP>:3100/api/datasources/proxy/1/api/v1/query?query=tracker_announces_total"
+  "http://<VM_IP>:3000/api/datasources/proxy/1/api/v1/query?query=tracker_announces_total"
 ```
 
 **Key verification points:**
@@ -519,7 +519,7 @@ Finally, verify that the Grafana dashboards can display the data:
 
 **Via Browser:**
 
-1. Open Grafana: `http://<VM_IP>:3100/`
+1. Open Grafana: `http://<VM_IP>:3000/`
 2. Login with your credentials (admin / SecurePassword123!)
 3. Navigate to Dashboards → Browse
 4. Open the "Torrust Tracker" folder
@@ -537,7 +537,7 @@ Finally, verify that the Grafana dashboards can display the data:
 ```bash
 # Query via Grafana datasource proxy
 curl -u admin:SecurePassword123! \
-  "http://<VM_IP>:3100/api/datasources/proxy/1/api/v1/query?query=swarm_coordination_registry_torrents_total{job=\"tracker_metrics\"}" | jq .
+  "http://<VM_IP>:3000/api/datasources/proxy/1/api/v1/query?query=swarm_coordination_registry_torrents_total{job=\"tracker_metrics\"}" | jq .
 ```
 
 **Expected output:**
@@ -588,7 +588,7 @@ docker ps -a | grep grafana
 
 **Common causes:**
 
-- Port 3100 already in use on the VM
+- Port 3000 already in use on the VM
 - Invalid environment variable in `.env` file
 - Insufficient permissions on data directory
 
@@ -596,14 +596,14 @@ docker ps -a | grep grafana
 
 **Symptoms:**
 
-- `curl http://<VM_IP>:3100/` times out or connection refused
+- `curl http://<VM_IP>:3000/` times out or connection refused
 - Browser cannot load the page
 
 **Diagnosis:**
 
 ```bash
 # Check if port is listening
-ssh torrust@<VM_IP> "netstat -tlnp | grep 3100"
+ssh torrust@<VM_IP> "netstat -tlnp | grep 3000"
 
 # Check container networking
 docker inspect <grafana_container_id> | grep IPAddress
@@ -804,18 +804,15 @@ Use this checklist when verifying a Grafana deployment:
 For a complete verification, you can also test through the Grafana web UI:
 
 1. **Login**:
-
-   - Navigate to `http://<VM_IP>:3100/`
+   - Navigate to `http://<VM_IP>:3000/`
    - Login with your configured credentials
 
 2. **Check Datasource**:
-
    - Go to Configuration → Data Sources
    - Verify "Prometheus" datasource exists
    - Click "Test" button → should show "Data source is working"
 
 3. **Explore Metrics**:
-
    - Go to Explore (compass icon in sidebar)
    - Select "Prometheus" datasource
    - Try queries:

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -321,7 +321,7 @@ The Torrust Tracker Deployer supports optional services that can be enabled in y
   - Can be disabled by removing from configuration
 
 - **[Grafana Visualization](services/grafana.md)** - Metrics visualization and dashboards (enabled by default)
-  - Web UI on port 3100 for dashboard access
+  - Web UI on port 3000 for dashboard access
   - Requires Prometheus to be enabled
   - Configurable admin credentials
   - Pre-built tracker dashboards available for import

--- a/docs/user-guide/quick-start/docker.md
+++ b/docs/user-guide/quick-start/docker.md
@@ -214,7 +214,7 @@ After deployment, your services are available at (replace `<IP>` with your serve
 | UDP Tracker  | `udp://<IP>:6969/announce`  | BitTorrent UDP tracker announce        |
 | Tracker API  | `http://<IP>:1212/api`      | Requires `admin_token` for auth        |
 | Health Check | `http://<IP>:1313/health`   | Bound to localhost only (internal)     |
-| Grafana      | `http://<IP>:3100`          | Metrics dashboard (admin credentials)  |
+| Grafana      | `http://<IP>:3000`          | Metrics dashboard (admin credentials)  |
 | Prometheus   | `http://localhost:9090`     | Internal only - not exposed externally |
 
 > **Note**: The health check endpoint (`1313`) is bound to `127.0.0.1` by default for security. Access it via SSH if needed.

--- a/docs/user-guide/security.md
+++ b/docs/user-guide/security.md
@@ -17,7 +17,6 @@ Security is a critical aspect of production deployments. The Torrust Tracker Dep
 The deployer implements security at two levels:
 
 1. **Instance-Level Security (UFW)** - Protects the VM itself
-
    - Denies all incoming traffic by default
    - Allows only SSH access for administration
    - **Does NOT control Docker container ports** (Docker bypasses UFW)
@@ -74,7 +73,7 @@ services:
 
   grafana:
     ports:
-      - "3100:3000" # Public - Monitoring UI (authenticated)
+      - "3000:3000" # Public - Monitoring UI (authenticated)
 
   # 🔒 LOCALHOST-ONLY SERVICES - Bound to 127.0.0.1
   prometheus:

--- a/docs/user-guide/services/grafana.md
+++ b/docs/user-guide/services/grafana.md
@@ -10,7 +10,7 @@ The deployer includes Grafana for metrics visualization by default. Grafana prov
 
 - **Enabled by default** in generated environment templates
 - **Requires Prometheus** to be enabled (hard dependency)
-- Web UI accessible on port `3100`
+- Web UI accessible on port `3000`
 - Default admin credentials: `admin` / `admin` (should be changed)
 - Uses Docker named volume for persistent storage
 
@@ -60,7 +60,7 @@ Add the `grafana` section to your environment configuration file:
 - Boolean to enable HTTPS via Caddy reverse proxy
 - Default: `false` (HTTP only)
 - Requires `domain` to be set
-- When enabled, port 3100 is not exposed; access is via HTTPS (port 443)
+- When enabled, port 3000 is not exposed; access is via HTTPS (port 443)
 
 **Examples**:
 
@@ -137,7 +137,7 @@ After deployment, the Grafana web UI is available at:
 **HTTP (default)**:
 
 ```text
-http://<vm-ip>:3100
+http://<vm-ip>:3000
 ```
 
 **HTTPS (when TLS enabled)**:
@@ -162,7 +162,7 @@ Look for the "Instance IP" field in the output.
 
 ### First Login
 
-1. Open `http://<vm-ip>:3100` in your web browser
+1. Open `http://<vm-ip>:3000` in your web browser
 2. Enter your credentials:
    - **Username**: Value from `grafana.admin_user` in your config
    - **Password**: Value from `grafana.admin_password` in your config
@@ -316,16 +316,16 @@ For detailed step-by-step verification instructions, see the [Grafana Verificati
 ssh torrust@<vm-ip> "docker ps | grep grafana"
 
 # 2. Check Grafana is accessible
-curl -u admin:SecurePassword123! http://<vm-ip>:3100/api/health
+curl -u admin:SecurePassword123! http://<vm-ip>:3000/api/health
 
 # Expected output: {"commit":"...","database":"ok","version":"11.4.0"}
 
 # 3. Verify login credentials
-curl -u admin:SecurePassword123! http://<vm-ip>:3100/api/org
+curl -u admin:SecurePassword123! http://<vm-ip>:3000/api/org
 # Should return HTTP 200 with organization info
 
 # 4. Test with wrong credentials (should fail)
-curl -u admin:wrongpassword http://<vm-ip>:3100/api/org
+curl -u admin:wrongpassword http://<vm-ip>:3000/api/org
 # Should return HTTP 401 Unauthorized
 ```
 
@@ -372,7 +372,7 @@ torrust-tracker-deployer run <env-name>
 
 ### Grafana UI Not Accessible
 
-**Symptom**: Browser cannot connect to `http://<vm-ip>:3100`.
+**Symptom**: Browser cannot connect to `http://<vm-ip>:3000`.
 
 **Diagnosis**:
 
@@ -381,11 +381,11 @@ torrust-tracker-deployer run <env-name>
 ssh torrust@<vm-ip> "docker ps | grep grafana"
 
 # 2. Check port binding
-ssh torrust@<vm-ip> "docker ps | grep grafana" | grep "3100"
-# Should show: 0.0.0.0:3100->3000/tcp
+ssh torrust@<vm-ip> "docker ps | grep grafana" | grep "3000"
+# Should show: 0.0.0.0:3000->3000/tcp
 
 # 3. Test from VM itself
-ssh torrust@<vm-ip> "curl -s http://localhost:3100/api/health"
+ssh torrust@<vm-ip> "curl -s http://localhost:3000/api/health"
 
 # 4. Check container logs
 ssh torrust@<vm-ip> "docker logs grafana"
@@ -394,7 +394,7 @@ ssh torrust@<vm-ip> "docker logs grafana"
 **Common Solutions**:
 
 - Container not running: `docker start grafana`
-- Port conflict: Check if port 3100 is already in use
+- Port conflict: Check if port 3000 is already in use
 - Network issues: Verify Docker network `backend_network` exists
 
 ### Prometheus Datasource Connection Fails
@@ -453,7 +453,7 @@ curl http://<vm-ip>:8080/api/v1/metrics
 ```text
 VM Instance
 ├── Docker Containers
-│   ├── grafana (port 3100 → 3000)
+│   ├── grafana (port 3000)
 │   ├── prometheus (port 9090)
 │   └── tracker (port 8080)
 ├── Docker Networks
@@ -481,11 +481,10 @@ docker run --rm -v grafana_data:/data -v $(pwd):/backup \
 
 ### Port Exposure
 
-**Port Mapping**: `3100:3000` (Host:Container)
+**Port Mapping**: `3000:3000` (Host:Container)
 
-- **Host Port**: `3100` - Accessible from outside VM
+- **Host Port**: `3000` - Accessible from outside VM
 - **Container Port**: `3000` - Grafana's default internal port
-- **Reason for 3100**: Avoid conflicts with other services commonly using port 3000
 
 **Security Note**: Docker published ports **bypass UFW firewall rules**. The port is accessible from any network that can reach the host. This is acceptable for development/testing but requires reverse proxy with TLS for production (see roadmap).
 

--- a/docs/user-guide/services/https.md
+++ b/docs/user-guide/services/https.md
@@ -324,7 +324,7 @@ When HTTPS is enabled for a service:
 | ------------ | ------------------------- | ------------------------------------- |
 | Tracker API  | Port exposed (e.g., 1212) | Port hidden, accessed via Caddy (443) |
 | HTTP Tracker | Port exposed (e.g., 7070) | Port hidden, accessed via Caddy (443) |
-| Grafana      | Port 3100 exposed         | Port hidden, accessed via Caddy (443) |
+| Grafana      | Port 3000 exposed         | Port hidden, accessed via Caddy (443) |
 
 **Security benefit**: Backend service ports are not exposed when TLS is enabled, reducing attack surface.
 

--- a/src/application/command_handlers/show/info/grafana.rs
+++ b/src/application/command_handlers/show/info/grafana.rs
@@ -31,7 +31,7 @@ impl GrafanaInfo {
 
     /// Build `GrafanaInfo` from instance IP (HTTP direct access)
     ///
-    /// Grafana is exposed on port 3100 (mapped from internal port 3000).
+    /// Grafana is exposed on port 3000 (same as internal port).
     ///
     /// # Panics
     ///
@@ -39,7 +39,7 @@ impl GrafanaInfo {
     /// never happen since we construct a valid URL from a valid IP address.
     #[must_use]
     pub fn from_instance_ip(instance_ip: IpAddr) -> Self {
-        let url = Url::parse(&format!("http://{instance_ip}:3100")) // DevSkim: ignore DS137138
+        let url = Url::parse(&format!("http://{instance_ip}:3000")) // DevSkim: ignore DS137138
             .expect("Valid IP address should produce valid URL");
         Self::new(url, false)
     }
@@ -73,7 +73,7 @@ mod tests {
 
     #[test]
     fn it_should_create_grafana_info_from_url() {
-        let url = Url::parse("http://10.0.0.1:3100").unwrap(); // DevSkim: ignore DS137138
+        let url = Url::parse("http://10.0.0.1:3000").unwrap(); // DevSkim: ignore DS137138
         let info = GrafanaInfo::new(url.clone(), false);
         assert_eq!(info.url, url);
         assert!(!info.uses_https);
@@ -84,7 +84,7 @@ mod tests {
         let ip = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100));
         let info = GrafanaInfo::from_instance_ip(ip);
         assert_eq!(info.url.host_str(), Some("192.168.1.100"));
-        assert_eq!(info.url.port(), Some(3100));
+        assert_eq!(info.url.port(), Some(3000));
         assert!(!info.uses_https);
     }
 
@@ -114,7 +114,7 @@ mod tests {
 
         assert_eq!(info.url.scheme(), "http");
         assert_eq!(info.url.host_str(), Some("10.0.0.1"));
-        assert_eq!(info.url.port(), Some(3100));
+        assert_eq!(info.url.port(), Some(3000));
         assert!(!info.uses_https);
     }
 }

--- a/src/infrastructure/remote_actions/validators/grafana.rs
+++ b/src/infrastructure/remote_actions/validators/grafana.rs
@@ -12,7 +12,7 @@
 //!
 //! ## Validation Approach
 //!
-//! Grafana is exposed on port 3100 via Docker, but validation is performed
+//! Grafana is exposed on port 3000 via Docker, but validation is performed
 //! from inside the VM via SSH for consistency with other service validators:
 //!
 //! 1. Connect to VM via SSH
@@ -20,15 +20,15 @@
 //! 3. Verify successful HTTP response (200 OK)
 //!
 //! This smoke test confirms Grafana is:
-//! - Running and bound to the expected port (3000 internally, 3100 externally)
+//! - Running and bound to the expected port (3000 internally and externally)
 //! - Responding to HTTP requests
 //! - Web UI is functional
 //!
 //! ## Port Mapping
 //!
 //! - Internal (container): 3000 (Grafana default)
-//! - External (host): 3100 (docker-compose port mapping)
-//! - Validation uses: 3100 (tests the published port from inside VM)
+//! - External (host): 3000 (docker-compose port mapping, same as internal)
+//! - Validation uses: 3000 (tests the published port from inside VM)
 //!
 //! ## Future Enhancements
 //!
@@ -37,13 +37,13 @@
 //! 1. **Authentication Validation**:
 //!    - Test admin login with configured credentials
 //!    - Verify authentication works correctly
-//!    - Example: `curl -u admin:password http://localhost:3100/api/health`
+//!    - Example: `curl -u admin:password http://localhost:3000/api/health`
 //!
 //! 2. **Datasource Validation**:
 //!    - Query Grafana API for configured datasources
 //!    - Verify Prometheus datasource is configured
 //!    - Check datasource connectivity to Prometheus
-//!    - Example: `curl http://localhost:3100/api/datasources | jq`
+//!    - Example: `curl http://localhost:3000/api/datasources | jq`
 //!
 //! 3. **Dashboard Availability**:
 //!    - Query for available dashboards
@@ -67,7 +67,7 @@ use crate::adapters::ssh::SshConfig;
 use crate::infrastructure::remote_actions::{RemoteAction, RemoteActionError};
 
 /// Default Grafana external port (exposed by docker-compose)
-const DEFAULT_GRAFANA_PORT: u16 = 3100;
+const DEFAULT_GRAFANA_PORT: u16 = 3000;
 
 /// Maximum retry attempts for Grafana startup
 const MAX_RETRIES: u32 = 30;
@@ -86,7 +86,7 @@ impl GrafanaValidator {
     ///
     /// # Arguments
     /// * `ssh_config` - SSH connection configuration containing credentials and host IP
-    /// * `grafana_port` - Port where Grafana is accessible (defaults to 3100 if None)
+    /// * `grafana_port` - Port where Grafana is accessible (defaults to 3000 if None)
     #[must_use]
     pub fn new(ssh_config: SshConfig, grafana_port: Option<u16>) -> Self {
         let ssh_client = SshClient::new(ssh_config);

--- a/src/presentation/views/commands/show/environment_info/grafana.rs
+++ b/src/presentation/views/commands/show/environment_info/grafana.rs
@@ -44,7 +44,7 @@ mod tests {
 
     fn http_grafana() -> GrafanaInfo {
         GrafanaInfo::new(
-            Url::parse("http://10.0.0.1:3100").unwrap(), // DevSkim: ignore DS137138
+            Url::parse("http://10.0.0.1:3000").unwrap(), // DevSkim: ignore DS137138
             false,
         )
     }
@@ -70,7 +70,7 @@ mod tests {
     #[test]
     fn it_should_render_http_url() {
         let lines = GrafanaView::render(&http_grafana());
-        assert!(lines.iter().any(|l| l.contains("http://10.0.0.1:3100"))); // DevSkim: ignore DS137138
+        assert!(lines.iter().any(|l| l.contains("http://10.0.0.1:3000"))); // DevSkim: ignore DS137138
     }
 
     #[test]

--- a/src/testing/e2e/tasks/run_run_validation.rs
+++ b/src/testing/e2e/tasks/run_run_validation.rs
@@ -101,7 +101,7 @@ Tip: Ensure Prometheus container is running and accessible on port 9090"
     /// Grafana smoke test failed
     #[error(
         "Grafana smoke test failed: {source}
-Tip: Ensure Grafana container is running and accessible on port 3100"
+Tip: Ensure Grafana container is running and accessible on port 3000"
     )]
     GrafanaValidationFailed {
         #[source]
@@ -192,12 +192,12 @@ For more information, see docs/e2e-testing/."
    - View Grafana logs: docker compose logs grafana
 
 2. Verify Grafana is accessible:
-   - Test from inside VM: curl http://localhost:3100
-   - Check if port 3100 is listening: ss -tlnp | grep 3100
+   - Test from inside VM: curl http://localhost:3000
+   - Check if port 3000 is listening: ss -tlnp | grep 3000
 
 3. Common issues:
    - Grafana container failed to start (check logs)
-   - Port 3100 already in use by another process
+   - Port 3000 already in use by another process
    - Invalid admin credentials in environment variables
    - Insufficient memory for Grafana
    - Grafana depends on Prometheus but Prometheus not running
@@ -205,8 +205,8 @@ For more information, see docs/e2e-testing/."
 4. Debug steps:
    - Check environment variables: docker compose exec grafana env | grep GF_
    - Restart Grafana: docker compose restart grafana
-   - Access Grafana UI: http://<vm-ip>:3100 (from your browser)
-   - Check datasources: curl http://localhost:3100/api/datasources | jq
+   - Access Grafana UI: http://<vm-ip>:3000 (from your browser)
+   - Check datasources: curl http://localhost:3000/api/datasources | jq
 
 5. Re-deploy if needed:
    - Release command: cargo run -- release <environment>
@@ -359,7 +359,7 @@ async fn validate_prometheus(
 ///
 /// # Note
 ///
-/// Grafana runs on port 3000 inside the container but is exposed on port 3100
+/// Grafana runs on port 3000 inside the container and is exposed on port 3000
 /// on the host via docker-compose port mapping. Docker published ports bypass
 /// UFW firewall, so Grafana is accessible externally. However, for consistency
 /// with other validators, we test from inside the VM via SSH.

--- a/templates/docker-compose/docker-compose.yml.tera
+++ b/templates/docker-compose/docker-compose.yml.tera
@@ -139,7 +139,7 @@ services:
 {%- endfor %}
 {%- if not grafana.has_tls %}
     ports:
-      - "3100:3000"
+      - "3000:3000"
 {%- endif %}
     environment:
       - GF_SECURITY_ADMIN_USER=${GF_SECURITY_ADMIN_USER}


### PR DESCRIPTION
## Summary

Changes the Grafana default port from 3100 to 3000, aligning with the industry standard.

## Changes

- **Template**: Updated `docker-compose.yml.tera` to expose Grafana on port 3000
- **Source code**: Updated `DEFAULT_GRAFANA_PORT` constant and all test assertions
- **Documentation**: Updated all active docs referencing port 3100
- **ADR**: Added `grafana-default-port-3000.md` documenting the decision

## Files Modified

### Template
- `templates/docker-compose/docker-compose.yml.tera` - Port mapping `3100:3000` → `3000:3000`

### Rust Source
- `src/infrastructure/remote_actions/validators/grafana.rs` - Constant and docs
- `src/application/command_handlers/show/info/grafana.rs` - URL generation and tests
- `src/presentation/views/commands/show/environment_info/grafana.rs` - Test fixtures
- `src/testing/e2e/tasks/run_run_validation.rs` - Error messages

### Documentation
- 10 documentation files updated (user guides, security docs, ADRs, e2e testing)
- New ADR created: `docs/decisions/grafana-default-port-3000.md`

## Rationale

Port 3000 is the industry standard for Grafana. The original use of port 3100 was a workaround for macOS port conflicts, but:
1. Port 3000 never actually conflicted with macOS services
2. Users expect Grafana on port 3000
3. Most documentation and tutorials use port 3000

## Testing

- ✅ All 1848 unit tests pass
- ✅ All 15 integration tests pass
- ✅ Clippy lint check passes
- ✅ Rustfmt check passes
- ✅ Markdown lint passes

Fixes #275