### PR TITLE
fix: [#277] remove public MySQL port exposure for security

### DIFF
--- a/src/infrastructure/templating/docker_compose/template/renderer/docker_compose.rs
+++ b/src/infrastructure/templating/docker_compose/template/renderer/docker_compose.rs
@@ -301,10 +301,10 @@ mod tests {
             "Volume should use local driver"
         );
 
-        // Verify port mapping
+        // Verify port is NOT exposed (security fix: https://github.com/torrust/torrust-tracker-deployer/issues/277)
         assert!(
-            content.contains("3306:3306"),
-            "Should expose MySQL port 3306"
+            !content.contains("3306:3306"),
+            "MySQL port 3306 should NOT be exposed externally for security"
         );
     }
 

--- a/templates/docker-compose/docker-compose.yml.tera
+++ b/templates/docker-compose/docker-compose.yml.tera
@@ -176,8 +176,11 @@ services:
 {%- for network in mysql.networks %}
       - {{ network }}
 {%- endfor %}
-    ports:
-      - "3306:3306"
+    # SECURITY: MySQL port is NOT exposed to the host/external network.
+    # - Only the tracker container can access MySQL via Docker's internal database_network
+    # - The healthcheck runs inside the container, so no external port is needed
+    # - This prevents unauthorized external access to the database
+    # See: https://github.com/torrust/torrust-tracker-deployer/issues/277
     volumes:
       - mysql_data:/var/lib/mysql
     command: --mysql-native-password=ON


### PR DESCRIPTION
## Summary

Fixes a security vulnerability where MySQL port 3306 was publicly accessible from outside the VM, allowing anyone on the network to connect to the database.

## Problem

The MySQL service in the Docker Compose template exposed port 3306 to all network interfaces:
```yaml
ports:
  - "3306:3306"
```

This allowed external connections to the database:
```bash
$ mysql -h <VM_IP> -P 3306 -u tracker_user -p -e "SELECT 1;"
+---+
| 1 |
+---+
| 1 |
+---+
```

## Solution

Removed the `ports` section from the MySQL service. The database remains accessible to the Tracker container through Docker's internal `database_network`, and the healthcheck still works because `mysqladmin ping` runs inside the container.

## Changes

- Removed `ports: - "3306:3306"` from MySQL service in `docker-compose.yml.tera`
- Added security comment explaining why port is not exposed
- Updated unit test to verify port is NOT exposed

## Verification

Tested by deploying a MySQL environment and confirming:
- ✅ `nc -zv <VM_IP> 3306` times out (port not accessible externally)
- ✅ All containers report healthy status including MySQL
- ✅ Tracker can still connect to MySQL via internal Docker network

## Related

Closes #277

---

**Issue Specification**: [docs/issues/277-mysql-port-publicly-exposed.md](docs/issues/277-mysql-port-publicly-exposed.md)