### PR TITLE
fix: [#290] remove dead Grafana-without-Prometheus template branch

### DIFF
--- a/templates/docker-compose/docker-compose.yml.tera
+++ b/templates/docker-compose/docker-compose.yml.tera
@@ -154,12 +154,8 @@ services:
       retries: 5
       start_period: 30s
     depends_on:
-{%- if prometheus %}
       prometheus:
         condition: service_healthy
-{%- else %}
-      - tracker
-{%- endif %}
 {%- endif %}
 {%- if mysql %}
 


### PR DESCRIPTION
## Summary

Removes dead code from the Docker Compose template that handled an impossible configuration state (Grafana enabled without Prometheus).

## Related Issues

- Closes #290
- Part of Epic #287 (Docker Compose Topology Domain Model Refactoring)

## Changes

- Removed unreachable `{%- else %}` branch in Grafana `depends_on` section
- The domain layer already validates that Grafana requires Prometheus (`GrafanaRequiresPrometheus` error in `src/domain/environment/user_inputs.rs`)
- The template's conditional branch handling "Grafana without Prometheus" could never be executed

## Before

```yaml
    depends_on:
{%- if prometheus %}
      prometheus:
        condition: service_healthy
{%- else %}
      - tracker
{%- endif %}
```

## After

```yaml
    depends_on:
      prometheus:
        condition: service_healthy
```

## Verification

- [x] Domain validation confirms this configuration is impossible
- [x] Pre-commit checks pass
- [x] E2E tests pass