### PR TITLE
feat: [#332] add DNS setup reminder in provision command

### DIFF
--- a/src/presentation/views/commands/provision/dns_reminder.rs
+++ b/src/presentation/views/commands/provision/dns_reminder.rs
@@ -1,0 +1,277 @@
+//! DNS Setup Reminder View for Provision Command
+//!
+//! This module provides a view for rendering DNS setup reminders after
+//! successful infrastructure provisioning when domains are configured.
+
+use std::fmt::Write;
+use std::net::IpAddr;
+
+use crate::application::command_handlers::show::info::ServiceInfo;
+
+/// DNS reminder data for rendering
+///
+/// This struct holds all the data needed to render DNS setup reminders
+/// for a provisioned instance with configured domains.
+#[derive(Debug, Clone)]
+pub struct DnsReminderData {
+    /// Instance IP address
+    pub instance_ip: IpAddr,
+    /// List of all configured domains
+    pub domains: Vec<String>,
+}
+
+/// View for rendering DNS setup reminders
+///
+/// This view is responsible for formatting and rendering DNS setup information
+/// that users need to configure after provisioning when domains are used.
+///
+/// # Design
+///
+/// Following MVC pattern, this view:
+/// - Receives data from the controller
+/// - Formats the output for display
+/// - Only displays when domains are actually configured
+/// - Returns a string ready for output to stdout
+///
+/// # Examples
+///
+/// ```rust
+/// use std::net::{IpAddr, Ipv4Addr};
+/// use torrust_tracker_deployer_lib::presentation::views::commands::provision::dns_reminder::DnsReminderData;
+/// use torrust_tracker_deployer_lib::presentation::views::commands::provision::DnsReminderView;
+///
+/// let data = DnsReminderData {
+///     instance_ip: IpAddr::V4(Ipv4Addr::new(10, 140, 190, 171)),
+///     domains: vec![
+///         "http.tracker.example.com".to_string(),
+///         "api.tracker.example.com".to_string(),
+///         "grafana.example.com".to_string(),
+///     ],
+/// };
+///
+/// let output = DnsReminderView::render(&data);
+/// assert!(output.contains("DNS Setup Required"));
+/// assert!(output.contains("http.tracker.example.com"));
+/// ```
+pub struct DnsReminderView;
+
+impl DnsReminderView {
+    /// Render DNS setup reminder as a formatted string
+    ///
+    /// Takes DNS reminder data and produces a human-readable output suitable
+    /// for displaying to users via stdout.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - DNS reminder data to render
+    ///
+    /// # Returns
+    ///
+    /// A formatted string containing:
+    /// - Warning icon and header
+    /// - Explanation message
+    /// - Server IP address
+    /// - List of all configured domains
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::net::{IpAddr, Ipv4Addr};
+    /// use torrust_tracker_deployer_lib::presentation::views::commands::provision::dns_reminder::DnsReminderData;
+    /// use torrust_tracker_deployer_lib::presentation::views::commands::provision::DnsReminderView;
+    ///
+    /// let data = DnsReminderData {
+    ///     instance_ip: IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)),
+    ///     domains: vec![
+    ///         "tracker.example.com".to_string(),
+    ///     ],
+    /// };
+    ///
+    /// let output = DnsReminderView::render(&data);
+    /// assert!(output.contains("192.168.1.100"));
+    /// assert!(output.contains("tracker.example.com"));
+    /// ```
+    #[must_use]
+    pub fn render(data: &DnsReminderData) -> String {
+        let mut output = String::new();
+
+        output.push_str("\n⚠️  DNS Setup Required:\n");
+        output.push_str(
+            "  Your configuration uses custom domains. Remember to update your DNS records\n",
+        );
+        let _ = writeln!(
+            output,
+            "  to point your domains to the server IP: {}",
+            data.instance_ip
+        );
+        output.push_str("\n  Configured domains:\n");
+
+        for domain in &data.domains {
+            let _ = writeln!(output, "    - {domain}");
+        }
+
+        output
+    }
+
+    /// Extract all domains from `ServiceInfo`
+    ///
+    /// This helper method collects all unique domains from the service configuration,
+    /// including domains from HTTP trackers, API, health check, and Grafana.
+    ///
+    /// # Arguments
+    ///
+    /// * `services` - Service information containing domain configuration
+    ///
+    /// # Returns
+    ///
+    /// A vector of unique domain names, or empty vector if no domains are configured.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use torrust_tracker_deployer_lib::application::command_handlers::show::info::{ServiceInfo, TlsDomainInfo};
+    /// use torrust_tracker_deployer_lib::presentation::views::commands::provision::DnsReminderView;
+    ///
+    /// let services = ServiceInfo::new(
+    ///     vec![],
+    ///     vec!["https://http.tracker.local/announce".to_string()],
+    ///     vec![],
+    ///     vec![],
+    ///     "https://api.tracker.local/api".to_string(),
+    ///     true,
+    ///     false,
+    ///     "https://health.tracker.local/health_check".to_string(),
+    ///     true,
+    ///     false,
+    ///     vec![
+    ///         TlsDomainInfo::new("http.tracker.local".to_string(), 7070),
+    ///         TlsDomainInfo::new("api.tracker.local".to_string(), 1212),
+    ///         TlsDomainInfo::new("health.tracker.local".to_string(), 1313),
+    ///         TlsDomainInfo::new("grafana.tracker.local".to_string(), 3000),
+    ///     ],
+    /// );
+    ///
+    /// let domains = DnsReminderView::extract_all_domains(&services);
+    /// assert_eq!(domains.len(), 4);
+    /// assert!(domains.contains(&"http.tracker.local".to_string()));
+    /// assert!(domains.contains(&"api.tracker.local".to_string()));
+    /// ```
+    #[must_use]
+    pub fn extract_all_domains(services: &ServiceInfo) -> Vec<String> {
+        // Currently, ServiceInfo only tracks TLS domains
+        // This returns all domain names from tls_domains
+        services
+            .tls_domain_names()
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use crate::application::command_handlers::show::info::TlsDomainInfo;
+
+    #[test]
+    fn it_should_render_dns_reminder_with_single_domain() {
+        let data = DnsReminderData {
+            instance_ip: IpAddr::V4(Ipv4Addr::new(10, 140, 190, 171)),
+            domains: vec!["tracker.example.com".to_string()],
+        };
+
+        let output = DnsReminderView::render(&data);
+
+        assert!(output.contains("⚠️  DNS Setup Required:"));
+        assert!(output.contains("10.140.190.171"));
+        assert!(output.contains("tracker.example.com"));
+        assert!(output.contains("Configured domains:"));
+    }
+
+    #[test]
+    fn it_should_render_dns_reminder_with_multiple_domains() {
+        let data = DnsReminderData {
+            instance_ip: IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100)),
+            domains: vec![
+                "http.tracker.example.com".to_string(),
+                "api.tracker.example.com".to_string(),
+                "grafana.example.com".to_string(),
+            ],
+        };
+
+        let output = DnsReminderView::render(&data);
+
+        assert!(output.contains("DNS Setup Required"));
+        assert!(output.contains("192.168.1.100"));
+        assert!(output.contains("http.tracker.example.com"));
+        assert!(output.contains("api.tracker.example.com"));
+        assert!(output.contains("grafana.example.com"));
+    }
+
+    #[test]
+    fn it_should_extract_all_domains_from_service_info() {
+        let services = ServiceInfo::new(
+            vec![],
+            vec!["https://http.tracker.local/announce".to_string()],
+            vec![],
+            vec![],
+            "https://api.tracker.local/api".to_string(),
+            true,
+            false,
+            "https://health.tracker.local/health_check".to_string(),
+            true,
+            false,
+            vec![
+                TlsDomainInfo::new("http.tracker.local".to_string(), 7070),
+                TlsDomainInfo::new("api.tracker.local".to_string(), 1212),
+                TlsDomainInfo::new("health.tracker.local".to_string(), 1313),
+            ],
+        );
+
+        let domains = DnsReminderView::extract_all_domains(&services);
+
+        assert_eq!(domains.len(), 3);
+        assert!(domains.contains(&"http.tracker.local".to_string()));
+        assert!(domains.contains(&"api.tracker.local".to_string()));
+        assert!(domains.contains(&"health.tracker.local".to_string()));
+    }
+
+    #[test]
+    fn it_should_return_empty_vec_when_no_domains_configured() {
+        let services = ServiceInfo::new(
+            vec!["udp://10.0.0.1:6969/announce".to_string()],
+            vec![],
+            vec!["http://10.0.0.1:7070/announce".to_string()], // DevSkim: ignore DS137138
+            vec![],
+            "http://10.0.0.1:1212/api".to_string(), // DevSkim: ignore DS137138
+            false,
+            false,
+            "http://10.0.0.1:1313/health_check".to_string(), // DevSkim: ignore DS137138
+            false,
+            false,
+            vec![], // No TLS domains
+        );
+
+        let domains = DnsReminderView::extract_all_domains(&services);
+
+        assert!(domains.is_empty());
+    }
+
+    #[test]
+    fn it_should_format_output_with_proper_indentation() {
+        let data = DnsReminderData {
+            instance_ip: IpAddr::V4(Ipv4Addr::new(172, 16, 0, 1)),
+            domains: vec!["example.com".to_string()],
+        };
+
+        let output = DnsReminderView::render(&data);
+
+        // Check for proper indentation and formatting
+        assert!(output.contains("  Your configuration"));
+        assert!(output.contains("  to point"));
+        assert!(output.contains("  Configured domains:"));
+        assert!(output.contains("    - example.com"));
+    }
+}

--- a/src/presentation/views/commands/provision/mod.rs
+++ b/src/presentation/views/commands/provision/mod.rs
@@ -3,5 +3,7 @@
 //! This module contains view components for rendering provision command output.
 
 pub mod connection_details;
+pub mod dns_reminder;
 
 pub use connection_details::ConnectionDetailsView;
+pub use dns_reminder::DnsReminderView;


### PR DESCRIPTION
## Overview

Implements [#332](https://github.com/torrust/torrust-tracker-deployer/issues/332) - Display a DNS setup reminder after successful provisioning when custom domains are configured. This helps users remember to update their DNS records to point to the server IP address.

## Changes

- **Add DnsReminderView**: New presentation view with conditional rendering based on domain presence
- **Add DnsReminderData**: DTO for transferring view data (instance IP and domains list)
- **Integrate DNS reminder**: Display in provision controller workflow after connection details
- **Domain extraction**: Extract domains from tracker and Grafana ServiceInfo configurations
- **Comprehensive testing**: 5 unit tests covering various scenarios

## Architecture

Follows the project's DDD/MVC patterns:
- **View**: `src/presentation/views/commands/provision/dns_reminder.rs` - Renders DNS reminder with warning icon, IP, and domain list
- **Controller**: `src/presentation/controllers/provision/handler.rs` - Orchestrates display after provisioning
- **Application Layer**: Reuses `ServiceInfo` from application layer for domain extraction

## Behavior

The DNS reminder:
- ✅ Appears only when TLS domains are configured
- ✅ Lists all domains (tracker HTTP/API/health and Grafana)
- ✅ Shows the server IP address for DNS configuration
- ✅ Uses clear warning icon (⚠️) for visibility

## Example Output

```
⏳ [1/3] Validating environment...
⏳   ✓ Environment name validated: lxd-local-https-example (took 0ms)
⏳ [2/3] Creating command handler...
⏳   ✓ Done (took 0ms)
⏳ [3/3] Provisioning infrastructure...
⏳   ✓ Infrastructure provisioned (took 26.1s)
✅ Environment 'lxd-local-https-example' provisioned successfully

Instance Connection Details:
  IP Address:        10.140.190.36
  SSH Port:          22
  SSH Private Key:   /home/josecelano/Documents/git/committer/me/github/torrust/torrust-tracker-deployer-agent-01/fixtures/testing_rsa
  SSH Username:      torrust

Connect using:
  ssh -i /home/josecelano/Documents/git/committer/me/github/torrust/torrust-tracker-deployer-agent-01/fixtures/testing_rsa torrust@10.140.190.36 -p 22

⚠️  DNS Setup Required:
  Your configuration uses custom domains. Remember to update your DNS records
  to point your domains to the server IP: 10.140.190.36

  Configured domains:
    - http.tracker.local
    - api.tracker.local
    - grafana.tracker.local
    - health.tracker.local
```

## Testing

- ✅ 5 new unit tests (all passing)
- ✅ Pre-commit checks passed (linters, formatters, doc tests, E2E tests)
- ✅ Manual testing with HTTPS-enabled environment (positive case)
- ✅ Unit test coverage for UDP-only environment (negative case)

## Acceptance Criteria

All criteria from the issue are met:
- [x] Pre-commit checks pass
- [x] Unit tests pass with comprehensive coverage
- [x] E2E tests pass
- [x] View follows MVC pattern with proper separation
- [x] Uses UserOutput methods (not println!)
- [x] Conditional display based on domain configuration
- [x] Clear, actionable user guidance