### PR TITLE
fix: [#313] use ansible_user instead of root for compose files ownership

### DIFF
--- a/templates/ansible/deploy-compose-files.yml
+++ b/templates/ansible/deploy-compose-files.yml
@@ -36,17 +36,17 @@
         path: "{{ remote_deploy_dir }}"
         state: directory
         mode: "0755"
-        owner: root
-        group: root
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
 
     - name: Copy Docker Compose files to remote host
       ansible.builtin.copy:
         src: "{{ local_compose_dir }}/"
         dest: "{{ remote_deploy_dir }}/"
-        mode: "0644"
+        mode: "0640"
         directory_mode: "0755"
-        owner: root
-        group: root
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
 
     - name: Verify docker-compose.yml exists on remote
       ansible.builtin.stat:


### PR DESCRIPTION
## Summary

Fixes the file ownership issue in the `deploy-compose-files.yml` Ansible playbook where files were being deployed with `root:root` ownership instead of using `ansible_user`, causing security concerns and inconsistencies with other playbooks.

## Changes

Updated `templates/ansible/deploy-compose-files.yml`:

1. **Directory creation task** - Changed owner/group from `root` to `{{ ansible_user }}`
2. **File copy task** - Changed owner/group from `root` to `{{ ansible_user }}`
3. **Security improvement** - Changed file mode from `0644` to `0640` (more restrictive for `.env` files containing secrets)

## Testing

- ✅ E2E Infrastructure Lifecycle Tests - Passed (42.3s)
- ✅ E2E Deployment Workflow Tests - Passed (106.3s)
- ✅ Manual Deployment Verification - Confirmed correct ownership
  - `/opt/torrust/docker-compose.yml` → `torrust:torrust` with mode `640`
  - `/opt/torrust/.env` → `torrust:torrust` with mode `640`
  - All storage directories → consistent `torrust:torrust` ownership
- ✅ All Linters - Passed (markdown, yaml, toml, cspell, clippy, rustfmt, shellcheck)

## Impact

- **Security**: Files containing secrets (`.env`) are now owned by the app user instead of root
- **Consistency**: All files in `/opt/torrust/` have uniform ownership pattern matching other playbooks
- **Permissions**: Mode `0640` prevents world-readable access to sensitive configuration files

Closes #313