### PR TITLE
ci: add cargo fetch step to measure download vs build time

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -106,6 +106,10 @@ jobs:
         name: Enable Workflow Cache
         uses: Swatinem/rust-cache@v2
 
+      - id: fetch
+        name: Download Dependencies
+        run: cargo fetch --verbose
+
       - id: build
         name: Build Project
         run: cargo build --verbose --workspace --all-features


### PR DESCRIPTION
## 📊 Purpose

This PR adds a separate `cargo fetch` step before the build step in the CI workflow to help measure:
- How much time is spent downloading dependencies
- How much time is spent on the actual build process

## 🔍 Context

We want to identify if dependency downloads are a bottleneck in our CI build process. By separating the download step (`cargo fetch`) from the build step (`cargo build`), we can measure each phase independently in the GitHub Actions logs.

## 📝 Changes

- Added a new step "Download Dependencies" that runs `cargo fetch --verbose` before the build step
- This allows us to see timing for each phase separately in the CI logs

## 🎯 Expected Outcome

After this PR is merged and the workflow runs, we'll be able to see:
1. Duration of dependency downloads (fetch step)
2. Duration of the actual compilation (build step)

This data will help determine if we need to optimize dependency caching or if the build time itself is the primary concern.

## ✅ Testing

- The workflow syntax is valid
- This change only adds observability without affecting functionality