### PR TITLE
Add JSON Output to Run Command

### DIFF
--- a/src/presentation/controllers/run/tests.rs
+++ b/src/presentation/controllers/run/tests.rs
@@ -13,6 +13,7 @@ use crate::domain::environment::repository::EnvironmentRepository;
 use crate::infrastructure::persistence::repository_factory::RepositoryFactory;
 use crate::presentation::controllers::constants::DEFAULT_LOCK_TIMEOUT;
 use crate::presentation::controllers::run::handler::RunCommandController;
+use crate::presentation::input::cli::OutputFormat;
 use crate::presentation::views::testing::TestUserOutput;
 use crate::presentation::views::{UserOutput, VerbosityLevel};
 use crate::shared::clock::Clock;
@@ -46,7 +47,7 @@ mod environment_name_validation {
         let (user_output, repository, clock) = create_test_dependencies(&temp_dir);
 
         let result = RunCommandController::new(repository, clock, user_output)
-            .execute("invalid_name")
+            .execute("invalid_name", OutputFormat::Text)
             .await;
 
         assert!(matches!(
@@ -61,7 +62,7 @@ mod environment_name_validation {
         let (user_output, repository, clock) = create_test_dependencies(&temp_dir);
 
         let result = RunCommandController::new(repository, clock, user_output)
-            .execute("")
+            .execute("", OutputFormat::Text)
             .await;
 
         assert!(matches!(
@@ -76,7 +77,7 @@ mod environment_name_validation {
         let (user_output, repository, clock) = create_test_dependencies(&temp_dir);
 
         let result = RunCommandController::new(repository, clock, user_output)
-            .execute("-invalid")
+            .execute("-invalid", OutputFormat::Text)
             .await;
 
         assert!(matches!(
@@ -97,7 +98,7 @@ mod real_workflow {
 
         // Valid environment name but environment doesn't exist
         let result = RunCommandController::new(repository, clock, user_output)
-            .execute("production")
+            .execute("production", OutputFormat::Text)
             .await;
 
         assert!(
@@ -115,7 +116,7 @@ mod real_workflow {
         let (user_output, repository, clock) = create_test_dependencies(&temp_dir);
 
         let result = RunCommandController::new(repository, clock, user_output)
-            .execute("my-test-env")
+            .execute("my-test-env", OutputFormat::Text)
             .await;
 
         assert!(

--- a/src/presentation/dispatch/router.rs
+++ b/src/presentation/dispatch/router.rs
@@ -202,10 +202,11 @@ pub async fn route_command(
             Ok(())
         }
         Commands::Run { environment } => {
+            let output_format = context.output_format();
             context
                 .container()
                 .create_run_controller()
-                .execute(&environment)
+                .execute(&environment, output_format)
                 .await?;
             Ok(())
         }

--- a/src/presentation/views/commands/mod.rs
+++ b/src/presentation/views/commands/mod.rs
@@ -7,5 +7,6 @@
 pub mod create;
 pub mod list;
 pub mod provision;
+pub mod run;
 pub mod shared;
 pub mod show;

--- a/src/presentation/views/commands/run/json_view.rs
+++ b/src/presentation/views/commands/run/json_view.rs
@@ -1,0 +1,224 @@
+//! JSON View for Run Command Output
+//!
+//! This module provides JSON-based rendering for run command output.
+//! It follows the Strategy Pattern, providing a machine-readable output format
+//! for the same underlying data (`ServiceInfo` and `GrafanaInfo` DTOs).
+//!
+//! # Design
+//!
+//! The `JsonView` serializes service information to JSON using `serde_json`.
+//! The output includes the environment name, state (always "Running"), and
+//! service information from the existing DTOs.
+
+use serde::Serialize;
+
+use crate::application::command_handlers::show::info::{GrafanaInfo, ServiceInfo};
+
+/// DTO for JSON output of run command
+///
+/// This structure wraps the service information for JSON serialization.
+#[derive(Debug, Serialize)]
+struct RunCommandOutput<'a> {
+    environment_name: &'a str,
+    state: &'a str,
+    services: &'a ServiceInfo,
+    grafana: Option<&'a GrafanaInfo>,
+}
+
+/// View for rendering run command output as JSON
+///
+/// This view provides machine-readable JSON output for automation workflows
+/// and AI agents. It serializes service and Grafana information without
+/// any transformations.
+///
+/// # Examples
+///
+/// ```rust
+/// use torrust_tracker_deployer_lib::application::command_handlers::show::info::ServiceInfo;
+/// use torrust_tracker_deployer_lib::presentation::views::commands::run::JsonView;
+///
+/// let services = ServiceInfo::new(
+///     vec!["udp://10.0.0.1:6969/announce".to_string()],
+///     vec![],
+///     vec!["http://10.0.0.1:7070/announce".to_string()],
+///     vec![],
+///     "http://10.0.0.1:1212/api".to_string(),
+///     false,
+///     false,
+///     "http://10.0.0.1:1313/health_check".to_string(),
+///     false,
+///     false,
+///     vec![],
+/// );
+///
+/// let output = JsonView::render("my-env", &services, None);
+/// // Verify it's valid JSON
+/// let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+/// assert_eq!(parsed["environment_name"], "my-env");
+/// assert_eq!(parsed["state"], "Running");
+/// ```
+pub struct JsonView;
+
+impl JsonView {
+    /// Render run command output as JSON
+    ///
+    /// Serializes the service information to pretty-printed JSON format.
+    /// The state is always "Running" since this command only executes
+    /// when services are being started.
+    ///
+    /// # Arguments
+    ///
+    /// * `env_name` - Name of the environment
+    /// * `services` - Service information containing tracker endpoints
+    /// * `grafana` - Optional Grafana service information
+    ///
+    /// # Returns
+    ///
+    /// A JSON string containing the serialized run command output.
+    /// If serialization fails (which should never happen with valid data),
+    /// returns an error JSON object.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use torrust_tracker_deployer_lib::application::command_handlers::show::info::{
+    ///     ServiceInfo, GrafanaInfo,
+    /// };
+    /// use torrust_tracker_deployer_lib::presentation::views::commands::run::JsonView;
+    /// use url::Url;
+    ///
+    /// let services = ServiceInfo::new(
+    ///     vec!["udp://10.0.0.1:6969/announce".to_string()],
+    ///     vec![],
+    ///     vec!["http://10.0.0.1:7070/announce".to_string()],
+    ///     vec![],
+    ///     "http://10.0.0.1:1212/api".to_string(),
+    ///     false,
+    ///     false,
+    ///     "http://10.0.0.1:1313/health_check".to_string(),
+    ///     false,
+    ///     false,
+    ///     vec![],
+    /// );
+    ///
+    /// let grafana = GrafanaInfo::new(
+    ///     Url::parse("http://10.0.0.1:3000").unwrap(),
+    ///     false,
+    /// );
+    ///
+    /// let json = JsonView::render("my-env", &services, Some(&grafana));
+    /// // Verify it's valid JSON and has expected fields
+    /// let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    /// assert_eq!(parsed["environment_name"], "my-env");
+    /// assert!(parsed["services"].is_object());
+    /// assert!(parsed["grafana"].is_object());
+    /// ```
+    #[must_use]
+    pub fn render(env_name: &str, services: &ServiceInfo, grafana: Option<&GrafanaInfo>) -> String {
+        let output = RunCommandOutput {
+            environment_name: env_name,
+            state: "Running",
+            services,
+            grafana,
+        };
+
+        serde_json::to_string_pretty(&output)
+            .unwrap_or_else(|e| format!(r#"{{"error": "Failed to serialize: {e}"}}"#))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use url::Url;
+
+    use super::*;
+
+    fn sample_basic_services() -> ServiceInfo {
+        ServiceInfo::new(
+            vec!["udp://udp.tracker.local:6969/announce".to_string()],
+            vec![],
+            vec!["http://10.140.190.133:7070/announce".to_string()],
+            vec![],
+            "http://10.140.190.133:1212/api".to_string(),
+            false,
+            false,
+            "http://10.140.190.133:1313/health_check".to_string(),
+            false,
+            false,
+            vec![],
+        )
+    }
+
+    #[test]
+    fn it_should_render_basic_json_output() {
+        let services = sample_basic_services();
+        let output = JsonView::render("test-env", &services, None);
+
+        // Verify JSON structure
+        assert!(
+            output.contains(r#""environment_name":"test-env""#)
+                || output.contains(r#""environment_name": "test-env""#)
+        );
+        assert!(
+            output.contains(r#""state":"Running""#) || output.contains(r#""state": "Running""#)
+        );
+        assert!(output.contains(r#""services":"#));
+        assert!(output.contains(r#""grafana":null"#) || output.contains(r#""grafana": null"#));
+    }
+
+    #[test]
+    fn it_should_include_grafana_when_provided() {
+        let services = sample_basic_services();
+        let grafana = GrafanaInfo::new(Url::parse("http://10.140.190.133:3000").unwrap(), false);
+
+        let output = JsonView::render("test-env", &services, Some(&grafana));
+
+        // Verify grafana section exists
+        assert!(output.contains(r#""grafana":"#));
+        assert!(
+            output.contains(r#""url":"http://10.140.190.133:3000/""#)
+                || output.contains(r#""url": "http://10.140.190.133:3000/""#)
+        );
+        assert!(
+            output.contains(r#""uses_https":false"#) || output.contains(r#""uses_https": false"#)
+        );
+    }
+
+    #[test]
+    fn it_should_produce_valid_json() {
+        let services = sample_basic_services();
+        let output = JsonView::render("test-env", &services, None);
+
+        // Verify it's valid JSON by parsing it
+        let parsed: serde_json::Value =
+            serde_json::from_str(&output).expect("Output should be valid JSON");
+
+        // Verify key fields
+        assert_eq!(parsed["environment_name"], "test-env");
+        assert_eq!(parsed["state"], "Running");
+        assert!(parsed["services"].is_object());
+        assert!(parsed["grafana"].is_null());
+    }
+
+    #[test]
+    fn it_should_include_all_service_fields() {
+        let services = sample_basic_services();
+        let output = JsonView::render("test-env", &services, None);
+
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        let services_obj = &parsed["services"];
+
+        // Verify all service fields are present
+        assert!(services_obj["udp_trackers"].is_array());
+        assert!(services_obj["https_http_trackers"].is_array());
+        assert!(services_obj["direct_http_trackers"].is_array());
+        assert!(services_obj["localhost_http_trackers"].is_array());
+        assert!(services_obj["api_endpoint"].is_string());
+        assert!(services_obj["api_uses_https"].is_boolean());
+        assert!(services_obj["api_is_localhost_only"].is_boolean());
+        assert!(services_obj["health_check_url"].is_string());
+        assert!(services_obj["health_check_uses_https"].is_boolean());
+        assert!(services_obj["health_check_is_localhost_only"].is_boolean());
+        assert!(services_obj["tls_domains"].is_array());
+    }
+}

--- a/src/presentation/views/commands/run/mod.rs
+++ b/src/presentation/views/commands/run/mod.rs
@@ -1,0 +1,11 @@
+//! Views for the Run Command
+//!
+//! This module provides different rendering strategies for run command output.
+//! Following the Strategy Pattern, each view (`TextView`, `JsonView`) implements
+//! a different output format for the same underlying data (`ServiceInfo` and `GrafanaInfo` DTOs).
+
+mod json_view;
+mod text_view;
+
+pub use json_view::JsonView;
+pub use text_view::TextView;

--- a/src/presentation/views/commands/run/text_view.rs
+++ b/src/presentation/views/commands/run/text_view.rs
@@ -1,0 +1,165 @@
+//! Text View for Run Command Output
+//!
+//! This module provides human-readable text rendering for the run command.
+//! It displays service URLs, DNS hints, and helpful tips after services are started.
+
+use crate::application::command_handlers::show::info::{GrafanaInfo, ServiceInfo};
+use crate::presentation::views::commands::shared::service_urls::{
+    CompactServiceUrlsView, DnsHintView,
+};
+
+/// View for rendering run command output as human-readable text
+///
+/// This view displays service URLs and configuration hints after services
+/// have been started. It uses shared view components for consistency across
+/// commands.
+///
+/// # Examples
+///
+/// ```rust
+/// use torrust_tracker_deployer_lib::application::command_handlers::show::info::ServiceInfo;
+/// use torrust_tracker_deployer_lib::presentation::views::commands::run::TextView;
+///
+/// let services = ServiceInfo::new(
+///     vec!["udp://10.0.0.1:6969/announce".to_string()],
+///     vec![],
+///     vec!["http://10.0.0.1:7070/announce".to_string()],
+///     vec![],
+///     "http://10.0.0.1:1212/api".to_string(),
+///     false,
+///     false,
+///     "http://10.0.0.1:1313/health_check".to_string(),
+///     false,
+///     false,
+///     vec![],
+/// );
+///
+/// let output = TextView::render("my-env", &services, None);
+/// assert!(output.contains("Services are now accessible:"));
+/// assert!(output.contains("Tip:"));
+/// ```
+pub struct TextView;
+
+impl TextView {
+    /// Render run command output as human-readable text
+    ///
+    /// # Arguments
+    ///
+    /// * `env_name` - Name of the environment
+    /// * `services` - Service information containing tracker endpoints
+    /// * `grafana` - Optional Grafana service information
+    ///
+    /// # Returns
+    ///
+    /// A formatted string with service URLs, DNS hints (if applicable),
+    /// and a tip about using the show command for more details.
+    #[must_use]
+    pub fn render(env_name: &str, services: &ServiceInfo, grafana: Option<&GrafanaInfo>) -> String {
+        let mut output = Vec::new();
+
+        // Render service URLs (only public services)
+        let service_urls_output = CompactServiceUrlsView::render(services, grafana);
+        if !service_urls_output.is_empty() {
+            output.push(format!("\n{service_urls_output}"));
+        }
+
+        // Show DNS hint if HTTPS services are configured
+        if let Some(dns_hint) = DnsHintView::render(services) {
+            output.push(format!("\n{dns_hint}"));
+        }
+
+        // Show tip about show command
+        output.push(format!(
+            "\nTip: Run 'torrust-tracker-deployer show {env_name}' for full details\n"
+        ));
+
+        output.join("")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_basic_services() -> ServiceInfo {
+        ServiceInfo::new(
+            vec!["udp://udp.tracker.local:6969/announce".to_string()],
+            vec![],
+            vec!["http://10.140.190.133:7070/announce".to_string()],
+            vec![],
+            "http://10.140.190.133:1212/api".to_string(),
+            false,
+            false,
+            "http://10.140.190.133:1313/health_check".to_string(),
+            false,
+            false,
+            vec![],
+        )
+    }
+
+    #[test]
+    fn it_should_render_basic_output() {
+        let services = sample_basic_services();
+        let output = TextView::render("test-env", &services, None);
+
+        // Should contain service URLs
+        assert!(output.contains("Services are now accessible:"));
+        assert!(output.contains("udp://udp.tracker.local:6969/announce"));
+        assert!(output.contains("http://10.140.190.133:7070/announce"));
+        assert!(output.contains("http://10.140.190.133:1212/api"));
+
+        // Should contain tip
+        assert!(output.contains("Tip: Run 'torrust-tracker-deployer show test-env'"));
+
+        // Should NOT contain DNS hint (no HTTPS)
+        assert!(!output.contains("DNS"));
+    }
+
+    #[test]
+    fn it_should_include_grafana_when_provided() {
+        use url::Url;
+
+        let services = sample_basic_services();
+        let grafana = GrafanaInfo::new(Url::parse("http://10.140.190.133:3000").unwrap(), false);
+
+        let output = TextView::render("test-env", &services, Some(&grafana));
+
+        assert!(output.contains("Grafana:"));
+        assert!(output.contains("http://10.140.190.133:3000"));
+    }
+
+    #[test]
+    fn it_should_include_dns_hint_for_https_services() {
+        use crate::application::command_handlers::show::info::TlsDomainInfo;
+
+        let services = ServiceInfo::new(
+            vec!["udp://udp.tracker.local:6969/announce".to_string()],
+            vec!["https://http.tracker.local/announce".to_string()],
+            vec![],
+            vec![],
+            "https://api.tracker.local/api".to_string(),
+            true,
+            false,
+            "https://health.tracker.local/health_check".to_string(),
+            true,
+            false,
+            vec![
+                TlsDomainInfo::new("http.tracker.local".to_string(), 7070),
+                TlsDomainInfo::new("api.tracker.local".to_string(), 1212),
+            ],
+        );
+
+        let output = TextView::render("test-env", &services, None);
+
+        // Should contain DNS hint
+        assert!(output.contains("Note: HTTPS services require DNS configuration"));
+    }
+
+    #[test]
+    fn it_should_always_include_tip() {
+        let services = sample_basic_services();
+        let output = TextView::render("my-environment", &services, None);
+
+        assert!(output.contains("Tip: Run 'torrust-tracker-deployer show my-environment'"));
+    }
+}


### PR DESCRIPTION
## Description

Implements JSON output format for the `run` command following the Strategy Pattern established in #349, #352, and #355.

Closes #357

## Changes

### Implementation

- **TextView** (`src/presentation/views/commands/run/text_view.rs`): Refactors existing text output logic using shared components (`CompactServiceUrlsView` and `DnsHintView`)
- **JsonView** (`src/presentation/views/commands/run/json_view.rs`): Serializes `ServiceInfo` and `GrafanaInfo` to JSON with `environment_name` and state wrapper
- **RunCommandController**: Updated to accept `output_format` parameter and use Strategy Pattern to select appropriate view
- **Router**: Updated to pass `output_format` from `ExecutionContext` to controller

### Testing

- 4 unit tests for TextView (basic output, grafana, DNS hints, tip)
- 4 unit tests for JsonView (basic JSON, grafana, valid parsing, all fields)
- All existing tests updated to pass `OutputFormat::Text`
- All tests passing ✅
- All linters passing ✅

### Documentation

- Added comprehensive JSON output section to `docs/user-guide/commands/run.md`
- Documented JSON structure with examples for HTTP-only and HTTPS/TLS environments
- Included automation use cases with `jq` examples
- Documented all JSON fields with descriptions

## Architecture

Follows the established pattern from previous implementations:

1. **TextView**: Renders human-readable output with service URLs and DNS hints
2. **JsonView**: Renders machine-readable JSON for automation
3. **Controller**: Uses Strategy Pattern to select view based on `output_format`
4. **Router**: Extracts `output_format` from context and passes to controller

## Example Usage

### Text Output (default)
```bash
torrust-tracker-deployer run my-env
```

### JSON Output
```bash
torrust-tracker-deployer run my-env --output-format json
# Or short form:
torrust-tracker-deployer run my-env -o json
```

### JSON with jq
```bash
# Extract API endpoint
torrust-tracker-deployer run my-env -o json | jq -r '.services.api_endpoint'

# Check if HTTPS is enabled
torrust-tracker-deployer run my-env -o json | jq -r '.services.api_uses_https'

# Get all HTTP tracker URLs
torrust-tracker-deployer run my-env -o json | jq -r '.services | (.direct_http_trackers + .https_http_trackers)[]'
```

## Verification

- ✅ All unit tests pass
- ✅ All linters pass (markdown, yaml, toml, cspell, clippy, rustfmt, shellcheck)
- ✅ Follows established patterns from #349, #352, #355
- ✅ Documentation updated with examples and automation use cases
- ✅ Backward compatible (text output unchanged)

## Related Issues

- Part of EPIC #348 (Phase 1: JSON Output for High-Value Commands)
- Task 12.4 in project roadmap
- Follows pattern from:
  - #349 (create command)
  - #352 (provision command) 
  - #355 (show command)