### PR TITLE
refactor: [#374] convert Essential Rules to Agent Skills

### DIFF
--- a/.github/skills/add-ansible-playbook/skill.md
+++ b/.github/skills/add-ansible-playbook/skill.md
@@ -1,0 +1,85 @@
+---
+name: add-ansible-playbook
+description: Guide for adding Ansible playbooks to this project. Covers the atomic playbook rule (one playbook = one responsibility), the correct pattern for conditional enablement (in Rust commands/steps, NOT Ansible when: clauses), registering static playbooks in copy_static_templates(), the centralized variables.yml.tera pattern, and a checklist before adding. Use when creating new Ansible playbooks, adding Ansible tasks, or modifying the Ansible infrastructure. Triggers on "ansible playbook", "new playbook", "ansible task", "playbook", "add ansible", "copy_static_templates", or "infrastructure playbook".
+metadata:
+  author: torrust
+  version: "1.0"
+---
+
+# Adding Ansible Playbooks
+
+## Atomic Playbook Rule
+
+**One playbook = one responsibility.** Never bundle multiple unrelated tasks.
+
+```yaml
+# ✅ Good: single responsibility
+# install-docker.yml — only installs Docker
+
+# ❌ Bad: multiple concerns
+# install-docker-and-configure-firewall.yml
+```
+
+Red flags:
+
+- Playbook name contains "and"
+- Multiple unrelated `ansible.builtin.file` / copy tasks bundled together
+
+## Conditional Enablement Belongs in Rust
+
+Use `when:` **only for Ansible host facts** (OS detection, etc.).
+**Never use `when:` to decide if a feature/service is enabled.**
+
+```yaml
+# ✅ Good: host fact check
+- when: ansible_os_family == "Debian"
+
+# ❌ Bad: feature gating — this belongs in the Rust step
+- when: enable_monitoring == true
+```
+
+The Rust command/step decides which playbooks to run. New feature → new atomic playbook + new Rust step that conditionally calls it.
+
+## Registration in copy_static_templates()
+
+Every new static playbook (`.yml`, not `.tera`) must be registered:
+
+```text
+src/infrastructure/external_tools/ansible/template/renderer/project_generator.rs
+```
+
+In the `copy_static_templates()` function. Without this, the file is never copied to the build directory and Ansible won't find it.
+
+## Centralized Variables Pattern
+
+- `variables.yml.tera` — all runtime variables (rendered once by Tera)
+- `inventory.yml.tera` — connection details
+- Static playbooks load variables via `vars_files: [variables.yml]`
+
+When adding a new playbook that needs a runtime value, add the variable to `variables.yml.tera`, not to the playbook itself.
+
+```yaml
+# my-new-playbook.yml (static)
+---
+- name: Configure X
+  hosts: all
+  vars_files:
+    - variables.yml # ← always load centralized variables
+  tasks:
+    - name: Use variable
+      ansible.builtin.template:
+        src: "{{ my_variable }}" # ← from variables.yml
+```
+
+## Pre-Submit Checklist
+
+- [ ] Does one thing only (no "and" in the name)
+- [ ] No `when:` for feature/service enablement
+- [ ] `vars_files: [variables.yml]` included
+- [ ] Registered in `copy_static_templates()`
+- [ ] Corresponding Rust step added that calls this playbook
+
+## Reference
+
+Guide: [`docs/contributing/templates/ansible.md`](../../docs/contributing/templates/ansible.md)
+ADR: [`docs/decisions/atomic-ansible-playbooks.md`](../../docs/decisions/atomic-ansible-playbooks.md)

--- a/.github/skills/add-new-template/skill.md
+++ b/.github/skills/add-new-template/skill.md
@@ -1,0 +1,82 @@
+---
+name: add-new-template
+description: Guide for adding new templates to this project. Covers the Project Generator pattern, the difference between dynamic templates (.tera, automatically discovered) and static templates (must be explicitly registered in copy_static_templates()), and the two-level indirection design (embedded binary → external extraction → build directory rendering). Use when adding infrastructure templates, Ansible playbooks, OpenTofu files, or configuration templates. Triggers on "add template", "new template", "static template", "register template", "copy_static_templates", "project generator", or "template system".
+metadata:
+  author: torrust
+  version: "1.0"
+---
+
+# Adding New Templates
+
+## Two-Level Template Indirection
+
+```text
+Embedded in binary  →  data/templates/  →  build/{env}/
+  (compile time)       (extracted once)    (rendered per-run)
+```
+
+Templates live in `templates/` in the repo. They are compiled into the binary, extracted to `data/templates/` at first use, then rendered into `build/` with variables.
+
+## Template Types
+
+| Type        | Extension | Processing           | Discovery              |
+| ----------- | --------- | -------------------- | ---------------------- |
+| **Dynamic** | `.tera`   | Tera variable subst. | Auto by extension      |
+| **Static**  | Any       | File copy only       | Manual — must register |
+
+## Adding a Dynamic Template (`.tera`)
+
+1. Create the file in `templates/` with a `.tera` extension
+2. Use `{{ variable_name }}` syntax for runtime values
+3. **No additional registration needed** — automatically discovered
+
+```text
+templates/ansible/new-config.yml.tera
+```
+
+## Adding a Static Template
+
+Static templates (Ansible playbooks, fixed YAML, etc.) require explicit registration.
+
+### Step 1: Create the file
+
+```text
+templates/ansible/my-new-playbook.yml
+```
+
+### Step 2: Register in copy_static_templates()
+
+Find the appropriate `ProjectGenerator` for your template type:
+
+```text
+src/infrastructure/external_tools/ansible/template/renderer/project_generator.rs
+```
+
+Add your file to the `copy_static_templates()` function:
+
+```rust
+fn copy_static_templates(&self, ...) -> Result<(), Error> {
+    // existing registrations...
+    self.copy_template("ansible/my-new-playbook.yml", ...)?;
+    Ok(())
+}
+```
+
+**Without this step, the file will never appear in the build directory** and won't be available at runtime.
+
+## Ansible-Specific: Variables Pattern
+
+For Ansible playbooks, add runtime variables to `variables.yml.tera`, not the playbook. The playbook loads them via `vars_files: [variables.yml]`.
+
+## Checklist
+
+- [ ] File placed in `templates/` directory
+- [ ] If `.tera`: uses correct `{{ variable }}` syntax
+- [ ] If static: registered in `copy_static_templates()` in the project generator
+- [ ] New variables added to `variables.yml.tera` (for Ansible) or equivalent context
+
+## Reference
+
+Architecture: [`docs/contributing/templates/template-system-architecture.md`](../../docs/contributing/templates/template-system-architecture.md)
+Tera syntax: [`docs/contributing/templates/tera.md`](../../docs/contributing/templates/tera.md)
+Ansible guide: [`docs/contributing/templates/ansible.md`](../../docs/contributing/templates/ansible.md)

--- a/.github/skills/create-environment-variables/skill.md
+++ b/.github/skills/create-environment-variables/skill.md
@@ -1,0 +1,90 @@
+---
+name: create-environment-variables
+description: Guide for creating and naming environment variables in this project. All project environment variables must use the TORRUST_TD_ prefix. Covers the condition-based vs action-based naming decision framework, when to use each approach, and practical examples. Use when adding new environment variables, changing existing env var names, or deciding how to name a toggle or flag. Triggers on "environment variable", "env var", "TORRUST_TD_", "variable naming", "feature flag", "feature toggle", "configuration flag", or "add env var".
+metadata:
+  author: torrust
+  version: "1.0"
+---
+
+# Creating Environment Variables
+
+## Mandatory: TORRUST*TD* Prefix
+
+**All project environment variables must use the `TORRUST_TD_` prefix.**
+
+```bash
+# ✅ Good
+TORRUST_TD_SKIP_FIREWALL_IN_CONTAINER=true
+TORRUST_TD_LOG_LEVEL=debug
+
+# ❌ Bad: missing prefix
+SKIP_FIREWALL=true
+LOG_LEVEL=debug
+```
+
+The prefix prevents naming conflicts with system, OS, or tool environment variables.
+
+## Condition-Based vs Action-Based Naming
+
+### Condition-Based: "I am X" / "Running in X"
+
+Describes **context or state**. Use when the variable affects multiple behaviors.
+
+```bash
+TORRUST_TD_RUNNING_IN_AGENT_ENV=true   # affects logging, timeouts, interactivity
+```
+
+```rust
+if env::var("TORRUST_TD_RUNNING_IN_AGENT_ENV").unwrap_or_default() == "true" {
+    skip_slow_tests = true;
+    reduce_logging = true;
+    disable_interactive_prompts = true;
+}
+```
+
+### Action-Based: "Do X" / "Skip X"
+
+Describes **a specific behavior**. Use when the variable controls one thing.
+
+```bash
+TORRUST_TD_SKIP_FIREWALL_IN_CONTAINER=true  # controls one specific behavior
+```
+
+```rust
+if env::var("TORRUST_TD_SKIP_FIREWALL_IN_CONTAINER").unwrap_or_default() == "true" {
+    // only affects firewall step
+}
+```
+
+## Decision Framework
+
+```text
+Does this variable affect multiple subsystems?
+├─ YES → Condition-Based ("TORRUST_TD_IN_CI", "TORRUST_TD_IS_CONTAINER")
+└─ NO → Action-Based ("TORRUST_TD_SKIP_VALIDATION", "TORRUST_TD_ENABLE_X")
+
+Is it a platform/infrastructure concern?
+├─ YES → Condition-Based
+└─ NO → Action-Based
+```
+
+## Boolean Values Convention
+
+Use `"true"` or `"false"` (lowercase strings):
+
+```bash
+TORRUST_TD_SKIP_FIREWALL_IN_CONTAINER=true   # ✅
+TORRUST_TD_SKIP_FIREWALL_IN_CONTAINER=True   # ❌ (inconsistent)
+TORRUST_TD_SKIP_FIREWALL_IN_CONTAINER=1      # ❌ (use strings)
+```
+
+## Examples from the Codebase
+
+| Variable                                | Type   | Controls                      |
+| --------------------------------------- | ------ | ----------------------------- |
+| `TORRUST_TD_SKIP_FIREWALL_IN_CONTAINER` | Action | Skip UFW config in containers |
+
+## Reference
+
+Naming guide: [`docs/contributing/environment-variables-naming.md`](../../docs/contributing/environment-variables-naming.md)
+Prefix ADR: [`docs/decisions/environment-variable-prefix.md`](../../docs/decisions/environment-variable-prefix.md)

--- a/.github/skills/debug-test-errors/skill.md
+++ b/.github/skills/debug-test-errors/skill.md
@@ -1,0 +1,70 @@
+---
+name: debug-test-errors
+description: Guide for understanding expected errors and warnings in test output for this project. Covers SSH host key warnings (normal, expected, not failures), logging level meanings (ERROR vs WARN vs DEBUG), and when to be concerned vs when to ignore. Use when debugging E2E test output, seeing red or yellow warnings in tests, or investigating unexpected-looking log messages. Triggers on "test error", "test warning", "SSH warning", "E2E output", "debug test", "test failure", "known issue", "expected error", or "test output".
+metadata:
+  author: torrust
+  version: "1.0"
+---
+
+# Debugging Test Errors
+
+## Expected: SSH Host Key Warnings
+
+This warning is **normal and expected** — not a failure:
+
+```text
+WARN SSH warning detected, operation: "ssh_warning", host_ip: 127.0.0.1,
+Warning: Permanently added '[127.0.0.1]:32825' (ED25519) to the list of known hosts.
+```
+
+**Why it appears**: SSH connects to new hosts with `-o StrictHostKeyChecking=no` for automation.
+SSH adds the host key to `known_hosts` and informs us — this is normal security behavior.
+
+**What it means**: SSH is connecting successfully. This is working correctly.
+
+## Log Level Guide
+
+| Level   | Meaning                                         | Action required? |
+| ------- | ----------------------------------------------- | ---------------- |
+| `ERROR` | Actual failure requiring attention              | ✅ Yes           |
+| `WARN`  | Expected warning (e.g., SSH host key additions) | ❌ Usually no    |
+| `DEBUG` | Detailed execution info for troubleshooting     | ❌ No            |
+
+## When to Actually Be Concerned
+
+Contact the team or file an issue for:
+
+- **Process failures**: Overall command or test returns non-zero exit code
+- **Connection errors**: "Connection refused", "Host unreachable"
+- **Permission errors**: Unexpected "permission denied"
+- **Service failures**: Docker containers not starting
+- **Data corruption**: Invalid configs, lost state
+- **Unknown patterns**: Errors not listed in known-issues
+
+## How to Check if a Test Actually Failed
+
+The overall exit code matters, not individual WARN messages:
+
+```bash
+# Run E2E test — check exit code
+cargo run --bin e2e-infrastructure-lifecycle-tests; echo "Exit: $?"
+
+# Look for these indicators of real failure (not SSH warnings):
+# - "FAILED:", "ERROR:", "panicked at"
+# - Non-zero exit code
+```
+
+## Common False Alarms
+
+| What you see                           | Is it a failure? |
+| -------------------------------------- | ---------------- |
+| SSH host key WARN in test logs         | ❌ Expected      |
+| WARN-level log lines                   | ❌ Usually no    |
+| "Permanently added ... to known_hosts" | ❌ Expected      |
+| "Grafana not ready yet, retrying..."   | ❌ Expected      |
+| Test prints red/orange text            | Check exit code  |
+
+## Reference
+
+Known issues: [`docs/contributing/known-issues.md`](../../docs/contributing/known-issues.md)
+E2E testing: [`docs/e2e-testing/`](../../docs/e2e-testing/)

--- a/.github/skills/handle-errors-in-code/skill.md
+++ b/.github/skills/handle-errors-in-code/skill.md
@@ -1,0 +1,98 @@
+---
+name: handle-errors-in-code
+description: Guide for error handling in this Rust project. Covers the four principles (clarity, context, actionability, explicit enums over anyhow), the thiserror pattern for structured errors, including what/where/when/why context, writing actionable help text, and avoiding vague errors. Use when writing error types, handling Results, adding error variants, or reviewing error messages. Triggers on "error handling", "error type", "Result", "thiserror", "anyhow", "error enum", "error message", "handle error", or "add error variant".
+metadata:
+  author: torrust
+  version: "1.0"
+---
+
+# Handling Errors in Code
+
+## Core Principles
+
+1. **Clarity** — Users immediately understand what went wrong
+2. **Context** — Include what/where/when/why
+3. **Actionability** — Tell users how to fix it
+4. **Explicit enums over `anyhow`** — Prefer structured errors for pattern matching
+
+## Prefer Explicit Enum Errors
+
+```rust
+// ✅ Correct: explicit, matchable, clear
+#[derive(Debug, thiserror::Error)]
+pub enum ProvisionError {
+    #[error("Instance '{instance_name}' already exists in {provider}")]
+    InstanceAlreadyExists { instance_name: String, provider: String },
+
+    #[error("SSH key not found at '{path}'. Generate with: ssh-keygen -t ed25519 -f '{path}'")]
+    SshKeyNotFound { path: PathBuf },
+}
+
+// ❌ Wrong: opaque, hard to match
+return Err(anyhow::anyhow!("Something went wrong"));
+return Err("Invalid input".into());
+```
+
+## Include Actionable Fix Instructions in Display
+
+```rust
+impl Display for DeploymentError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SshKeyNotFound { path } => write!(
+                f,
+                "SSH key not found at '{}'.\n\n\
+                 To fix:\n\
+                 1. Generate: ssh-keygen -t ed25519 -f '{}'\n\
+                 2. Or specify --ssh-key-path",
+                path.display(), path.display()
+            ),
+        }
+    }
+}
+```
+
+## Context Requirements
+
+Each error should answer:
+
+- **What**: What operation was being performed?
+- **Where**: Which component, file, or resource?
+- **When**: Under what conditions?
+- **Why**: What caused the failure?
+
+```rust
+// ✅ Good: full context
+#[error("Network timeout during '{operation}' to '{endpoint}' after {timeout:?}. Check connectivity.")]
+NetworkTimeout { operation: String, timeout: Duration, endpoint: String },
+
+// ❌ Bad: no context
+return Err("timeout".into());
+```
+
+## Add help() for User-Facing Errors
+
+```rust
+impl ProvisionError {
+    pub fn help(&self) -> &'static str {
+        match self {
+            Self::InstanceAlreadyExists { .. } =>
+                "Use a different name or remove the existing instance with `destroy`.",
+            Self::SshKeyNotFound { .. } =>
+                "Run: ssh-keygen -t ed25519 or specify --ssh-key-path",
+        }
+    }
+}
+```
+
+## Quick Checklist
+
+- [ ] Error type uses `thiserror::Error` derive
+- [ ] Error message includes specific context (names, paths, values)
+- [ ] Error message includes fix instructions where possible
+- [ ] Prefer `enum` over `Box<dyn Error>` or `anyhow`
+- [ ] No vague messages like "invalid input" or "error occurred"
+
+## Reference
+
+Full guide: [`docs/contributing/error-handling.md`](../../docs/contributing/error-handling.md)

--- a/.github/skills/handle-secrets/skill.md
+++ b/.github/skills/handle-secrets/skill.md
@@ -1,0 +1,83 @@
+---
+name: handle-secrets
+description: Guide for handling sensitive data (secrets) in this Rust project. NEVER use String for API tokens, passwords, private keys, or database credentials. Use ApiToken or Password wrapper types from src/shared/secrets/, and PlainApiToken/PlainPassword at DTO boundaries. Call .expose_secret() only when the actual value is needed. Prevents accidental exposure through Debug output and logs. Use when working with credentials, API keys, tokens, passwords, or any sensitive configuration. Triggers on "secret", "API token", "password", "credential", "sensitive data", "ApiToken", "secrecy", or "expose secret".
+metadata:
+  author: torrust
+  version: "1.0"
+---
+
+# Handling Sensitive Data (Secrets)
+
+## Core Rule
+
+**NEVER use `String` for sensitive data.** Use wrapper types from `src/shared/secrets/`.
+
+```rust
+// ❌ WRONG: secret leaked in Debug output
+pub struct HetznerConfig {
+    pub api_token: String,
+}
+println!("{config:?}"); // → HetznerConfig { api_token: "hetzner_abc123" } — LEAKED!
+```
+
+```rust
+// ✅ CORRECT: secret redacted in Debug
+use crate::shared::secrets::ApiToken;
+pub struct HetznerConfig {
+    pub api_token: ApiToken,
+}
+println!("{config:?}"); // → HetznerConfig { api_token: Secret([REDACTED]) }
+```
+
+## Type Reference
+
+| Type            | Use for                                    | Where          |
+| --------------- | ------------------------------------------ | -------------- |
+| `ApiToken`      | Cloud API tokens, admin tokens, API keys   | Domain / Infra |
+| `Password`      | DB passwords, SSH passwords, service creds | Domain / Infra |
+| `PlainApiToken` | DTO boundaries accepting raw string input  | Config DTOs    |
+| `PlainPassword` | DTO boundaries accepting raw string input  | Config DTOs    |
+
+`PlainApiToken` and `PlainPassword` are type aliases for `String` — they signal "this will become a secret".
+
+## Using Secrets
+
+```rust
+use crate::shared::secrets::ApiToken;
+use secrecy::ExposeSecret;
+
+let token = ApiToken::from("my-api-token-123");
+
+// Only call .expose_secret() when making the actual API call
+let token_str: &str = token.expose_secret();
+```
+
+## DTO Boundary Pattern
+
+```rust
+use crate::shared::secrets::{PlainApiToken, ApiToken};
+
+// DTO layer (user input)
+#[derive(Deserialize)]
+pub struct HetznerSection {
+    pub api_token: PlainApiToken,  // signals "becomes secret"
+}
+
+// Convert to secret type before passing to domain
+let config = HetznerConfig {
+    api_token: ApiToken::from(dto.api_token),
+};
+```
+
+## Checklist
+
+- [ ] No `String` fields for tokens, passwords, or private keys
+- [ ] `ApiToken` or `Password` used in domain and infrastructure structs
+- [ ] `PlainApiToken`/`PlainPassword` used only at DTO/deserialization boundaries
+- [ ] `.expose_secret()` called only at the last moment (API call or connection string)
+- [ ] No `.expose_secret()` in log statements or error messages
+
+## Reference
+
+Full guide: [`docs/contributing/secret-handling.md`](../../docs/contributing/secret-handling.md)
+ADR: [`docs/decisions/secrecy-crate-for-sensitive-data.md`](../../docs/decisions/secrecy-crate-for-sensitive-data.md)

--- a/.github/skills/handle-user-output/skill.md
+++ b/.github/skills/handle-user-output/skill.md
@@ -1,0 +1,81 @@
+---
+name: handle-user-output
+description: Guide for producing user-facing output in this Rust project. NEVER use println!, eprintln!, print!, eprint!, or direct stdout/stderr access. Always use UserOutput via the execution context or ProgressReporter in controllers. Covers the sink-based output architecture, stdout vs stderr channel strategy, ProgressReporter for multi-step operations, verbosity control, and themes. Use when writing any user-visible output, progress messages, errors, or results. Triggers on "println", "print output", "user output", "UserOutput", "ProgressReporter", "display result", "output message", or "progress message".
+metadata:
+  author: torrust
+  version: "1.0"
+---
+
+# Handling User Output
+
+## Golden Rule
+
+**NEVER write directly to stdout/stderr.**
+
+```rust
+// ❌ FORBIDDEN
+println!("Processing...");
+eprintln!("Error occurred");
+std::io::stdout().write_all(b"data").unwrap();
+```
+
+```rust
+// ✅ CORRECT — use UserOutput
+let user_output = ctx.user_output();
+user_output.lock().borrow_mut().progress("Processing...");
+user_output.lock().borrow_mut().error("Error occurred");
+user_output.lock().borrow_mut().result("data");
+```
+
+## In Controllers: Use ProgressReporter
+
+Controllers use `ProgressReporter` (not `UserOutput` directly):
+
+```rust
+use crate::presentation::views::progress::ProgressReporter;
+use crate::presentation::views::UserOutput;
+
+pub struct ConfigureCommandController {
+    progress: ProgressReporter,
+}
+
+impl ConfigureCommandController {
+    pub fn new(user_output: Arc<ReentrantMutex<RefCell<UserOutput>>>) -> Self {
+        Self {
+            progress: ProgressReporter::new(user_output, 3), // 3 total steps
+        }
+    }
+
+    pub fn execute(&mut self) -> Result<(), Error> {
+        self.progress.start_step("Validating environment")?;
+        // ... do work ...
+        self.progress.complete_step(Some("Environment name validated: my-env"))?;
+
+        self.progress.start_step("Configuring infrastructure")?;
+        // ... do work ...
+        self.progress.complete_step(None)?;
+
+        Ok(())
+    }
+}
+```
+
+## Channel Strategy (stdout vs stderr)
+
+| Channel    | Use for                                         |
+| ---------- | ----------------------------------------------- |
+| **stdout** | Final results, structured data (JSON), pipeline |
+| **stderr** | Progress, status updates, warnings, errors      |
+
+This enables piping: `deployer create env | jq .status`
+
+## Why This Architecture?
+
+- **Testability**: Output captured and asserted in tests
+- **Verbosity control**: Centralized filtering
+- **Theme support**: emoji/plain/ASCII themes
+- **Channel routing**: Automatic stdout vs stderr
+
+## Reference
+
+Full guide: [`docs/contributing/output-handling.md`](../../docs/contributing/output-handling.md)

--- a/.github/skills/implement-domain-types/skill.md
+++ b/.github/skills/implement-domain-types/skill.md
@@ -1,0 +1,109 @@
+---
+name: implement-domain-types
+description: Guide for implementing domain types (value objects and entities) with invariants in this Rust project. Covers the "always valid" pattern with private fields and validated constructors, custom Deserialize implementations to prevent bypass, and expressive error types with actionable help text. Use when creating or modifying domain value objects, entities, or types with business rules. Triggers on "domain type", "value object", "entity", "invariant", "validated constructor", "domain entity", "DDD practices", "domain model", or "implement domain".
+metadata:
+  author: torrust
+  version: "1.0"
+---
+
+# Implementing Domain Types with Invariants
+
+## Core Rule: Domain Objects Are Always Valid
+
+After construction, a domain object must satisfy all its invariants. **Invalid objects must be impossible to create.**
+
+## Pattern 1: Value Object with Private Fields + Validated Constructor
+
+```rust
+// ✅ Correct
+pub struct EnvironmentName(String); // private field
+
+impl EnvironmentName {
+    pub fn new(name: String) -> Result<Self, EnvironmentNameError> {
+        if name.is_empty() {
+            return Err(EnvironmentNameError::Empty);
+        }
+        if name.contains(char::is_uppercase) {
+            return Err(EnvironmentNameError::UppercaseNotAllowed(name));
+        }
+        Ok(Self(name))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+```
+
+```rust
+// ❌ Wrong - allows invalid state
+pub struct EnvironmentName {
+    pub name: String, // public field, anyone can bypass validation
+}
+```
+
+## Pattern 2: Custom Deserialize (Required for Serde)
+
+`#[derive(Deserialize)]` bypasses the constructor — **always implement custom `Deserialize`**:
+
+```rust
+use serde::{Deserialize, Deserializer, Serialize};
+
+#[derive(Debug, Clone, Serialize)]  // Serialize can be derived
+pub struct HttpApiConfig {
+    bind_address: SocketAddr,        // private fields
+    use_tls_proxy: bool,
+}
+
+#[derive(Deserialize)]
+struct HttpApiConfigRaw {            // mirror struct for deserialization
+    bind_address: SocketAddr,
+    use_tls_proxy: bool,
+}
+
+impl<'de> Deserialize<'de> for HttpApiConfig {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = HttpApiConfigRaw::deserialize(deserializer)?;
+        HttpApiConfig::new(raw.bind_address, raw.use_tls_proxy)
+            .map_err(serde::de::Error::custom)
+    }
+}
+```
+
+## Pattern 3: Expressive Error Types with Help Text
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum HttpApiConfigError {
+    #[error("Dynamic port (port 0) is not supported: {0}")]
+    DynamicPortNotSupported(SocketAddr),
+
+    #[error("TLS proxy requires a domain to be specified")]
+    TlsProxyRequiresDomain,
+}
+
+impl HttpApiConfigError {
+    #[must_use]
+    pub fn help(&self) -> &'static str {
+        match self {
+            Self::DynamicPortNotSupported(_) =>
+                "Specify an explicit port number (e.g., 1212, 8080).",
+            Self::TlsProxyRequiresDomain =>
+                "Set a domain name or disable TLS proxy.",
+        }
+    }
+}
+```
+
+## Checklist
+
+- [ ] Fields are private (no `pub` on struct fields)
+- [ ] Validated constructor returns `Result<Self, Error>`
+- [ ] Custom `Deserialize` impl using a Raw mirror struct
+- [ ] Error type uses `thiserror::Error` with `help()` method
+- [ ] Single point of validation — not duplicated in setters/validators
+
+## Reference
+
+Full guide: [`docs/contributing/ddd-practices.md`](../../docs/contributing/ddd-practices.md)
+ADR: [`docs/decisions/validated-deserialization-for-domain-types.md`](../../docs/decisions/validated-deserialization-for-domain-types.md)

--- a/.github/skills/organize-rust-modules/skill.md
+++ b/.github/skills/organize-rust-modules/skill.md
@@ -1,0 +1,94 @@
+---
+name: organize-rust-modules
+description: Guide for organizing Rust modules and imports in this project. Covers import ordering (std → external crates → internal crate), preferring short imported names over fully-qualified paths, top-down module organization (public items first, high-level abstractions before low-level details), and placing error types at the end. Use when creating new Rust files, organizing module contents, adding imports, or reviewing code structure. Triggers on "module organization", "import order", "use statement", "Rust imports", "organize module", "code structure", or "module structure".
+metadata:
+  author: torrust
+  version: "1.0"
+---
+
+# Organizing Rust Modules
+
+## Rule 1: Imports Always First
+
+All `use` statements go at the top of the file, in three ordered groups:
+
+```rust
+// Group 1: Standard library
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+// Group 2: External crates
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+// Group 3: Internal crate (absolute paths first, then relative)
+use crate::domain::Environment;
+use crate::shared::Clock;
+use super::config::Config;
+```
+
+## Rule 2: Prefer Short Imported Names
+
+Always import types and use short names. Never use long inline paths.
+
+```rust
+// ✅ Good
+use std::sync::Arc;
+use crate::presentation::views::UserOutput;
+
+pub struct Handler {
+    output: Arc<UserOutput>,
+}
+```
+
+```rust
+// ❌ Bad: verbose, hard to read
+pub struct Handler {
+    output: std::sync::Arc<crate::presentation::views::UserOutput>,
+}
+```
+
+**Exception**: Full paths only when disambiguating same-named types:
+
+```rust
+use crate::domain::Environment as DomainEnvironment;
+// use full path for the other one to disambiguate
+fn compare(a: &DomainEnvironment, b: &crate::config::Environment) { ... }
+```
+
+## Rule 3: Top-Down Module Organization
+
+Order items within a module:
+
+1. **Public items first** — what consumers care about
+2. **High-level abstractions before low-level details**
+3. **Main responsibilities before secondary concerns**
+4. **Error types last** — `pub enum MyError { ... }`
+
+```rust
+// ✅ Good ordering in a module file
+pub struct MyCommand { ... }          // 1. Main public struct
+
+impl MyCommand {                      // 2. Primary implementation
+    pub fn new(...) -> Self { ... }
+    pub fn execute(...) -> Result<...> { ... }
+}
+
+fn helper_fn() { ... }                // 3. Private helpers
+
+#[derive(Debug, thiserror::Error)]    // 4. Error type last
+pub enum MyCommandError { ... }
+```
+
+## Quick Checklist
+
+- [ ] All `use` statements at top of file before any other items
+- [ ] `use` groups separated by blank lines (std, external, internal)
+- [ ] No inline full paths like `std::sync::Arc<crate::...>` in function bodies
+- [ ] Public items declared before private items in modules
+- [ ] Error types defined at the bottom of the module
+
+## Reference
+
+Full guide: [`docs/contributing/module-organization.md`](../../docs/contributing/module-organization.md)

--- a/.github/skills/place-code-in-ddd-layers/skill.md
+++ b/.github/skills/place-code-in-ddd-layers/skill.md
@@ -1,0 +1,98 @@
+---
+name: place-code-in-ddd-layers
+description: Guide for placing code in the correct DDD (Domain-Driven Design) layer in this Rust project. Covers the four-layer architecture (Domain, Application, Infrastructure, Presentation), dependency rules, what belongs in each layer, red flags for wrong placement, and a decision flowchart. Use when writing new code, refactoring, or moving code between layers. Triggers on "DDD layer", "which layer", "where does this code go", "domain layer", "application layer", "infrastructure layer", "presentation layer", "place code", or "layer placement".
+metadata:
+  author: torrust
+  version: "1.0"
+---
+
+# Placing Code in the Correct DDD Layer
+
+## Layer Overview
+
+```text
+Presentation  →  Application  →  Domain
+                 Infrastructure  →  Domain
+```
+
+**Dependency rule**: Dependencies flow inward toward Domain. Domain never depends on
+Application or Infrastructure.
+
+| Layer             | Path                  | Purpose                                         |
+| ----------------- | --------------------- | ----------------------------------------------- |
+| `domain/`         | `src/domain/`         | Business logic, entities, value objects, traits |
+| `application/`    | `src/application/`    | Commands, steps, use cases, DTOs                |
+| `infrastructure/` | `src/infrastructure/` | File I/O, SSH, OpenTofu, Ansible, HTTP          |
+| `presentation/`   | `src/presentation/`   | CLI definitions, output formatting, dispatch    |
+
+## What Belongs Where
+
+### Domain (`src/domain/`)
+
+✅ Value objects with validation (`EnvironmentName`, `Username`, `TraceId`)
+✅ Domain entities (`Environment<S>` type-state pattern)
+✅ Domain traits/interfaces (`Clock`, `EnvironmentRepository`)
+✅ Business rules and domain constraints
+✅ `#[derive(Serialize, Deserialize)]` on entities for persistence (pragmatic)
+
+❌ File I/O (`std::fs`, `tokio::fs`)
+❌ HTTP clients (`reqwest`, `hyper`)
+❌ External tools (OpenTofu, Ansible, SSH)
+❌ DTOs with raw `String` primitives
+
+### Application (`src/application/`)
+
+✅ Command handlers (`CreateCommand`, `ProvisionCommand`)
+✅ Steps orchestrated by commands
+✅ DTOs for data transfer across boundaries
+✅ Application services and use case logic
+
+❌ Business rules (belong in Domain)
+❌ External I/O (belongs in Infrastructure)
+❌ UI rendering (belongs in Presentation)
+
+### Infrastructure (`src/infrastructure/`)
+
+✅ SSH client, file system operations
+✅ OpenTofu and Ansible executors
+✅ Template renderers
+✅ Repository implementations
+✅ Custom serialization logic
+
+❌ Business logic (belongs in Domain)
+❌ Use case orchestration (belongs in Application)
+
+### Presentation (`src/presentation/`)
+
+✅ Clap CLI command definitions
+✅ `UserOutput` and `ProgressReporter`
+✅ Command dispatch / routing
+✅ Error display formatting
+
+❌ Business logic (belongs in Domain)
+❌ External I/O (belongs in Infrastructure)
+
+## Decision Flowchart
+
+```text
+Is it a business rule or invariant?
+├─ YES → Domain
+└─ NO → Does it orchestrate a use case?
+    ├─ YES → Application
+    └─ NO → Does it talk to external systems/files?
+        ├─ YES → Infrastructure
+        └─ NO → Is it CLI/UI concern?
+            └─ YES → Presentation
+```
+
+## Red Flags
+
+- `std::fs` or `tokio::fs` import in `domain/` → move to `infrastructure/`
+- Raw `String` DTO deriving `Deserialize` in `domain/` → move to `application/`
+- Business logic in `presentation/` → move to `domain/` or `application/`
+- `application/` importing from `presentation/` → forbidden dependency
+
+## Reference
+
+Full guide with examples: [`docs/contributing/ddd-layer-placement.md`](../../docs/contributing/ddd-layer-placement.md)
+Architecture overview: [`docs/codebase-architecture.md`](../../docs/codebase-architecture.md)

--- a/.github/skills/work-with-tera-templates/skill.md
+++ b/.github/skills/work-with-tera-templates/skill.md
@@ -1,0 +1,92 @@
+---
+name: work-with-tera-templates
+description: Guide for working with Tera template files (.tera extension) in this project. Covers correct variable syntax (double curly braces without spaces inside), avoiding Prettier IDE interference, the difference between dynamic .tera templates and static templates, and template file registration. Use when creating or editing .tera files, adding template variables, or troubleshooting template rendering. Triggers on "tera template", ".tera file", "template variable", "template syntax", "template rendering", "Tera", or "template file".
+metadata:
+  author: torrust
+  version: "1.0"
+---
+
+# Working with Tera Templates
+
+## Correct Variable Syntax
+
+Tera template files use `.tera` extension. Variables use **double curly braces**:
+
+```yaml
+# ✅ CORRECT
+{{ variable_name }}
+{{ username }}
+{{ ssh_public_key }}
+{{ instance_name }}
+```
+
+```yaml
+# ❌ WRONG — do NOT add spaces inside braces
+{ { variable_name } }
+
+# ❌ WRONG — single braces
+{ variable_name }
+```
+
+## Prettier IDE Problem
+
+VS Code's Prettier extension **will corrupt `.tera` files** by adding spaces inside braces.
+
+**Fix**: Add to `.prettierignore`:
+
+```gitignore
+# Prettier breaks Tera template syntax
+*.tera
+```
+
+Or in `.vscode/settings.json`:
+
+```json
+{
+  "[tera]": {
+    "editor.formatOnSave": false
+  }
+}
+```
+
+After applying the fix, manually remove any `{ { ... } }` patterns already introduced.
+
+## Static vs Dynamic Templates
+
+| Type        | Extension   | Processing              | Registration       |
+| ----------- | ----------- | ----------------------- | ------------------ |
+| **Dynamic** | `.tera`     | Tera variable rendering | Auto-discovered    |
+| **Static**  | `.yml` etc. | Direct file copy        | Must be registered |
+
+Tera files are automatically discovered. Static files must be explicitly registered.
+
+## Registering Static Templates
+
+Static templates (e.g., Ansible playbooks) must be added to `copy_static_templates()` in the project generator:
+
+```text
+src/infrastructure/external_tools/ansible/template/renderer/project_generator.rs
+```
+
+Without this, the file will not be copied into the build directory.
+
+## Examples
+
+```yaml
+# templates/ansible/inventory.yml.tera
+torrust_servers:
+  hosts:
+    torrust_vm:
+      ansible_host: { { ansible_host } }
+```
+
+```hcl
+# templates/tofu/variables.tfvars.tera
+instance_name = "{{ instance_name }}"
+ssh_public_key = "{{ ssh_public_key }}"
+```
+
+## Reference
+
+Syntax guide: [`docs/contributing/templates/tera.md`](../../docs/contributing/templates/tera.md)
+Architecture: [`docs/contributing/templates/template-system-architecture.md`](../../docs/contributing/templates/template-system-architecture.md)

--- a/.github/skills/write-markdown-docs/skill.md
+++ b/.github/skills/write-markdown-docs/skill.md
@@ -1,0 +1,75 @@
+---
+name: write-markdown-docs
+description: Guide for writing Markdown documentation in this project. Covers GitHub Flavored Markdown pitfalls, especially the critical #NUMBER pattern that auto-links to GitHub issues and PRs (NEVER use #1, #2, #3 as step/list numbers). Use ordered lists or plain numbers instead. Covers intentional vs accidental autolinks for issues, @mentions, and commit SHAs. Use when writing .md files, documentation, issue descriptions, PR descriptions, or README updates. Triggers on "markdown", "write docs", "documentation", "#number", "github markdown", "autolink", "markdown pitfall", or "GFM".
+metadata:
+  author: torrust
+  version: "1.0"
+---
+
+# Writing Markdown Documentation
+
+## Critical: #NUMBER Auto-links to GitHub Issues
+
+**GitHub automatically converts `#NUMBER` → link to issue/PR/discussion.**
+
+```markdown
+❌ Bad: accidentally links to issues
+
+- Task #1: Set up infrastructure ← links to GitHub issue #1
+- Task #2: Configure database ← links to GitHub issue #2
+
+Step #1: Install dependencies ← links to GitHub issue #1
+```
+
+**The links pollute the referenced issues with unrelated backlinks and confuse readers.**
+
+### Fix: Use Ordered Lists or Plain Numbers
+
+```markdown
+✅ Solution 1: Ordered list (automatic numbering)
+
+1. Set up infrastructure
+2. Configure database
+3. Deploy application
+
+✅ Solution 2: Plain numbers (no hash)
+
+- Task 1: Set up infrastructure
+- Task 2: Configure database
+
+✅ Solution 3: Alternative formats
+
+- Task (1): Set up infrastructure
+- Task [1]: Set up infrastructure
+- Task No. 1: Set up infrastructure
+```
+
+## When #NUMBER IS Intentional
+
+Use `#NUMBER` only when you explicitly want to link to that GitHub issue/PR:
+
+```markdown
+✅ Intentional: referencing issue
+This implements the behavior described in #42.
+Closes #374.
+Parent: #274 (Epic: Adopt Agent Skills)
+```
+
+## Other GFM Auto-links to Know
+
+```markdown
+@username → links to GitHub user profile (use intentionally for mentions)
+abc1234 (SHA) → links to commit (useful for references)
+owner/repo#42 → cross-repo issue link
+```
+
+## Checklist Before Committing Docs
+
+- [ ] No `#NUMBER` patterns used for enumeration or step numbering
+- [ ] Ordered lists use Markdown syntax `1.` `2.` `3.`
+- [ ] Any `#NUMBER` present is intentional issue/PR reference
+- [ ] Table formatting is consistent (use a Markdown linter)
+
+## Reference
+
+Full guide: [`docs/contributing/github-markdown-pitfalls.md`](../../docs/contributing/github-markdown-pitfalls.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,87 +82,9 @@ These principles should guide all development decisions, code reviews, and featu
 
 ## 🔧 Essential Rules
 
-1. **CRITICAL - Understanding `envs/` vs `data/` directories** (⚠️ **MOST FREQUENTLY VIOLATED RULE**):
+1. **CRITICAL — `data/` is READ ONLY** (⚠️ **MOST FREQUENTLY VIOLATED**): Never create or edit files in `data/` — it contains application-managed deployment state. User configs belong in `envs/`. These are completely different JSON structures with different purposes. See the `create-environment-config` skill for details.
 
-   **TWO COMPLETELY DIFFERENT FILE PURPOSES:**
-   - **`envs/` directory** - User Environment Configurations (USER INPUT):
-     - Purpose: User-created configuration files for environment creation
-     - Format: Environment creation schema (see `envs/environment-schema.json`)
-     - Contains: Provider config, SSH credentials, tracker settings, database config
-     - Usage: Passed to `create environment --env-file envs/your-config.json`
-     - Example: `envs/manual-test-mysql.json`
-     - Version Control: Gitignored (user-specific)
-     - **Rule**: You MAY create/edit files here as part of documentation or testing
-
-   - **`data/` directory** - Internal Application State (APPLICATION MANAGED):
-     - Purpose: Serialized Rust structs representing deployment state machine
-     - Format: Rust `Environment<State>` domain model serialization
-     - Contains: State transitions, runtime outputs, trace IDs, timestamps
-     - Usage: Internal state management, read-only inspection
-     - Example: `data/manual-test-mysql/environment.json` (NOT the same as `envs/manual-test-mysql.json`)
-     - Version Control: Gitignored (runtime-generated)
-     - **Rule**: You MUST NEVER create/edit files here - READ ONLY for debugging/verification
-
-   **NEVER CONFUSE THESE TWO!** When documenting or testing:
-   - User creates config in `envs/your-env.json`
-   - Application manages state in `data/your-env/environment.json`
-   - These are completely different JSON structures with different purposes
-
-2. **Before placing code in DDD layers**: Read [`docs/contributing/ddd-layer-placement.md`](docs/contributing/ddd-layer-placement.md) for comprehensive guidance on which code belongs in which layer (Domain, Application, Infrastructure, Presentation). This guide includes rules, red flags, examples, and a decision flowchart to help you make the right architectural decisions.
-
-3. **When implementing domain types with invariants**: Read [`docs/contributing/ddd-practices.md`](docs/contributing/ddd-practices.md) for domain patterns including validated constructors, custom deserialization, and error types. Domain objects must be "always valid" - use private fields, validated constructors, and custom `Deserialize` implementations. See the [Validated Deserialization ADR](docs/decisions/validated-deserialization-for-domain-types.md) for the full decision record.
-
-4. **Before creating branches**: Read [`docs/contributing/branching.md`](docs/contributing/branching.md) for naming conventions (`{issue-number}-{short-description}`)
-
-5. **Before committing**: Read [`docs/contributing/commit-process.md`](docs/contributing/commit-process.md) for conventional commits
-   - **With issue branch**: `{type}: [#{issue}] {description}` (when branch name starts with `{issue-number}-`)
-   - **Without issue branch**: `{type}: {description}` (when working on main or branch without issue number prefix)
-
-6. **Before committing**: Always run the pre-commit verification script - all checks must pass before staging files or creating commits, regardless of the tool or method used:
-
-   ```bash
-   ./scripts/pre-commit.sh
-   ```
-
-   This applies to **any** method of committing:
-   - Terminal: `git add`, `git commit`, `git commit -am`, `cd ../ && git add ...`, `git add . && git commit -m "..."`
-   - VS Code: Git panel, Source Control view, commit shortcuts
-   - IDEs: IntelliJ, CLion, RustRover git integration
-   - Git clients: GitHub Desktop, GitKraken, etc.
-   - CI/CD: Any automated commits or merges
-
-7. **Before working with Tera templates**: Read [`docs/contributing/templates/tera.md`](docs/contributing/templates/tera.md) for correct variable syntax - use `{{ variable }}` not `{ { variable } }`. Tera template files have the `.tera` extension.
-
-8. **When adding new Ansible playbooks**: Read [`docs/contributing/templates/ansible.md`](docs/contributing/templates/ansible.md) and the ADR [`atomic-ansible-playbooks.md`](docs/decisions/atomic-ansible-playbooks.md).
-   - **CRITICAL: One playbook = one responsibility** (atomic playbook rule)
-   - Conditional enablement belongs in Rust commands/steps, not in Ansible `when:` clauses (use `when:` only for host facts)
-   - Static playbooks must be registered in `src/infrastructure/external_tools/ansible/template/renderer/project_generator.rs` under `copy_static_templates()` so they are copied into the build directory
-
-9. **When handling errors in code**: Read [`docs/contributing/error-handling.md`](docs/contributing/error-handling.md) for error handling principles. Prefer explicit enum errors over anyhow for better pattern matching and user experience. Make errors clear, include sufficient context for traceability, and ensure they are actionable with specific fix instructions.
-
-10. **When producing any output to users** (CRITICAL for architecture): Read [`docs/contributing/output-handling.md`](docs/contributing/output-handling.md) for output handling conventions. **NEVER use `println!`, `eprintln!`, `print!`, `eprint!`, or direct access to `std::io::stdout()`/`std::io::stderr()`**. Always use `UserOutput` methods through the execution context. This ensures testability, consistent formatting, proper channel routing (stdout vs stderr), verbosity control, and theme support. Example: `ctx.user_output().lock().borrow_mut().progress("Processing...")` instead of `println!("Processing...")`.
-
-11. **Understanding expected errors**: Read [`docs/contributing/known-issues.md`](docs/contributing/known-issues.md) for known issues and expected behaviors. Some errors that appear red in E2E test output (like SSH host key warnings) are normal and expected - not actual failures.
-
-12. **Before making engineering decisions**: Document significant architectural or design decisions as Architectural Decision Records (ADRs) in `docs/decisions/`. Read [`docs/decisions/README.md`](docs/decisions/README.md) for the ADR template and guidelines. This ensures decisions are properly documented with context, rationale, and consequences for future reference.
-
-13. **When organizing code within modules**: Follow the module organization conventions in [`docs/contributing/module-organization.md`](docs/contributing/module-organization.md). Use top-down organization with public items first, high-level abstractions before low-level details, and important responsibilities before secondary concerns like error types.
-
-14. **When writing Rust imports** (CRITICAL for code style): Follow the import conventions in [`docs/contributing/module-organization.md`](docs/contributing/module-organization.md). Two essential rules:
-    - **Imports Always First**: Keep all imports at the top of the file, organized in groups (std → external crates → internal crate).
-    - **Prefer Imports Over Full Paths**: Always import types and use short names (e.g., `Arc<UserOutput>`) rather than fully-qualified paths. Never use long paths like `std::sync::Arc<crate::presentation::views::UserOutput>` in regular code - only use full paths when disambiguating naming conflicts.
-
-15. **When writing Markdown documentation**: Be aware of GitHub Flavored Markdown's automatic linking behavior. Read [`docs/contributing/github-markdown-pitfalls.md`](docs/contributing/github-markdown-pitfalls.md) for critical patterns to avoid. **NEVER use hash-number patterns for enumeration or step numbering** - this creates unintended links to GitHub issues/PRs. Use ordered lists or alternative formats instead.
-
-16. **When creating new environment variables**: Read [`docs/contributing/environment-variables-naming.md`](docs/contributing/environment-variables-naming.md) for comprehensive guidance on naming conventions (condition-based vs action-based), decision frameworks, and best practices. Also review [`docs/decisions/environment-variable-prefix.md`](docs/decisions/environment-variable-prefix.md) to ensure all project environment variables use the `TORRUST_TD_` prefix for proper namespacing and avoiding conflicts with system or user variables.
-
-17. **When adding new templates**: Read [`docs/contributing/templates/template-system-architecture.md`](docs/contributing/templates/template-system-architecture.md) to understand the Project Generator pattern. The `templates/` directory contains source templates. Dynamic templates (`.tera`) are automatically processed, but static files must be explicitly registered in their respective `ProjectGenerator` to be copied to the build directory.
-
-18. **When writing unit tests** (CRITICAL for test quality): Read [`docs/contributing/testing/unit-testing/naming-conventions.md`](docs/contributing/testing/unit-testing/naming-conventions.md) and follow the behavior-driven naming convention. **NEVER use the `test_` prefix** for test function names. Always use the `it_should_{expected_behavior}_when_{condition}` or `it_should_{expected_behavior}_given_{state}` pattern. This ensures tests clearly document the behavior being validated and the conditions under which it occurs. Example: `it_should_return_error_when_username_is_invalid()` instead of `test_invalid_username()`. Test names should follow the three-part structure (What-When-Then) and be descriptive enough that the test's purpose is clear without reading the code.
-
-19. **When handling sensitive data (secrets)** (CRITICAL for security): Read [`docs/contributing/secret-handling.md`](docs/contributing/secret-handling.md) for the complete guide. **NEVER use `String` for sensitive data like API tokens, passwords, private keys, or database credentials**. Always use wrapper types from `src/shared/secrets/`: `ApiToken` for API tokens, `Password` for passwords, and their plain type aliases (`PlainApiToken`/`PlainPassword`) at DTO boundaries. Call `.expose_secret()` only when the actual value is needed. See the [ADR](docs/decisions/secrecy-crate-for-sensitive-data.md) for architectural rationale.
-
-20. **When generating environment configurations** (for AI agents): Reference the Rust types in [`src/application/command_handlers/create/config/`](src/application/command_handlers/create/config/) for accurate constraint information. These types express richer validation rules than the JSON schema alone (e.g., `NonZeroU32`, tagged enums, newtype wrappers). Read the [README](src/application/command_handlers/create/config/README.md) in that folder for the full guide. The JSON schema (`schemas/environment-config.json`) provides basic structure, but the Rust types are authoritative for constraints. See the [ADR](docs/decisions/configuration-dto-layer-placement.md) for why these types are in the application layer.
+2. **Rust imports**: All imports at the top of the file, grouped (std → external crates → internal crate). Always prefer short imported names over fully-qualified paths (e.g., `Arc<UserOutput>`, not `std::sync::Arc<crate::presentation::views::UserOutput>`). Use full paths only to disambiguate naming conflicts.
 
 ## 🏗️ Deployed Instance Structure
 
@@ -228,28 +150,40 @@ The project provides Agent Skills in `.github/skills/` for specialized workflows
 
 Available skills:
 
-| Task                         | Skill to Load                                       |
-| ---------------------------- | --------------------------------------------------- |
-| Adding commands              | `.github/skills/add-new-command/skill.md`           |
-| Cleaning up completed issues | `.github/skills/cleanup-completed-issues/skill.md`  |
-| Cleaning LXD environments    | `.github/skills/clean-lxd-environments/skill.md`    |
-| Committing changes           | `.github/skills/commit-changes/skill.md`            |
-| Completing feature specs     | `.github/skills/complete-feature-spec/skill.md`     |
-| Completing refactor plans    | `.github/skills/complete-refactor-plan/skill.md`    |
-| Creating ADRs                | `.github/skills/create-adr/skill.md`                |
-| Creating environment configs | `.github/skills/create-environment-config/skill.md` |
-| Creating feature branches    | `.github/skills/create-feature-branch/skill.md`     |
-| Creating feature specs       | `.github/skills/create-feature-spec/skill.md`       |
-| Creating issues              | `.github/skills/create-issue/skill.md`              |
-| Creating new skills          | `.github/skills/add-new-skill/skill.md`             |
-| Creating refactor plans      | `.github/skills/create-refactor-plan/skill.md`      |
-| Regenerating CLI docs        | `.github/skills/regenerate-cli-docs/skill.md`       |
-| Rendering tracker artifacts  | `.github/skills/render-tracker-artifacts/skill.md`  |
-| Reviewing pull requests      | `.github/skills/review-pr/skill.md`                 |
-| Running linters              | `.github/skills/run-linters/skill.md`               |
-| Running local E2E tests      | `.github/skills/run-local-e2e-test/skill.md`        |
-| Running pre-commit checks    | `.github/skills/run-pre-commit-checks/skill.md`     |
-| Writing unit tests           | `.github/skills/write-unit-test/skill.md`           |
+| Task                           | Skill to Load                                          |
+| ------------------------------ | ------------------------------------------------------ |
+| Adding Ansible playbooks       | `.github/skills/add-ansible-playbook/skill.md`         |
+| Adding commands                | `.github/skills/add-new-command/skill.md`              |
+| Adding templates               | `.github/skills/add-new-template/skill.md`             |
+| Cleaning up completed issues   | `.github/skills/cleanup-completed-issues/skill.md`     |
+| Cleaning LXD environments      | `.github/skills/clean-lxd-environments/skill.md`       |
+| Committing changes             | `.github/skills/commit-changes/skill.md`               |
+| Completing feature specs       | `.github/skills/complete-feature-spec/skill.md`        |
+| Completing refactor plans      | `.github/skills/complete-refactor-plan/skill.md`       |
+| Creating ADRs                  | `.github/skills/create-adr/skill.md`                   |
+| Creating environment configs   | `.github/skills/create-environment-config/skill.md`    |
+| Creating environment variables | `.github/skills/create-environment-variables/skill.md` |
+| Creating feature branches      | `.github/skills/create-feature-branch/skill.md`        |
+| Creating feature specs         | `.github/skills/create-feature-spec/skill.md`          |
+| Creating issues                | `.github/skills/create-issue/skill.md`                 |
+| Creating new skills            | `.github/skills/add-new-skill/skill.md`                |
+| Creating refactor plans        | `.github/skills/create-refactor-plan/skill.md`         |
+| Debugging test errors          | `.github/skills/debug-test-errors/skill.md`            |
+| Handling errors in code        | `.github/skills/handle-errors-in-code/skill.md`        |
+| Handling secrets               | `.github/skills/handle-secrets/skill.md`               |
+| Handling user output           | `.github/skills/handle-user-output/skill.md`           |
+| Implementing domain types      | `.github/skills/implement-domain-types/skill.md`       |
+| Organizing Rust modules        | `.github/skills/organize-rust-modules/skill.md`        |
+| Placing code in DDD layers     | `.github/skills/place-code-in-ddd-layers/skill.md`     |
+| Regenerating CLI docs          | `.github/skills/regenerate-cli-docs/skill.md`          |
+| Rendering tracker artifacts    | `.github/skills/render-tracker-artifacts/skill.md`     |
+| Reviewing pull requests        | `.github/skills/review-pr/skill.md`                    |
+| Running linters                | `.github/skills/run-linters/skill.md`                  |
+| Running local E2E tests        | `.github/skills/run-local-e2e-test/skill.md`           |
+| Running pre-commit checks      | `.github/skills/run-pre-commit-checks/skill.md`        |
+| Working with Tera templates    | `.github/skills/work-with-tera-templates/skill.md`     |
+| Writing Markdown docs          | `.github/skills/write-markdown-docs/skill.md`          |
+| Writing unit tests             | `.github/skills/write-unit-test/skill.md`              |
 
 Skills supplement (not replace) the rules in this file. Rules apply always; skills activate when their workflows are needed.
 

--- a/project-words.txt
+++ b/project-words.txt
@@ -25,7 +25,6 @@ EAAAADAQABAAABAQC
 EPEL
 Falkenstein
 Gossman
-goroutines
 Grafana
 Grafonnet
 Graça
@@ -35,7 +34,6 @@ Hillsboro
 Hostnames
 ISAM
 Inno
-inspectable
 Kopia
 LUKS
 Liskov
@@ -96,6 +94,7 @@ aquasec
 aquasecurity
 architecting
 autocheckpoint
+autolinks
 autorestart
 backlinks
 bencoded
@@ -179,6 +178,7 @@ fswc
 getent
 getopt
 gobinary
+goroutines
 gosu
 gpgv
 handleable
@@ -194,6 +194,7 @@ hugepages
 idna
 impls
 incompletei
+inspectable
 instructionsets
 intervali
 ionice
@@ -290,8 +291,8 @@ pidfile
 pids
 pingoo
 pingooio
-pipefail
 pipeable
+pipefail
 pipx
 pkcs
 pkill


### PR DESCRIPTION
## Summary

Implements #374 — Refactor Essential Rules into Agent Skills.

The 20 Essential Rules in `AGENTS.md` have been converted to proper Agent Skills, reducing the always-loaded context from ~3000 tokens to ~100 tokens (2 slim rules).

## Changes

### New Agent Skills (12)

| Skill | Replaces Rule(s) |
|---|---|
| `add-ansible-playbook` | Rule 8 |
| `add-new-template` | Rule 17 |
| `create-environment-variables` | Rule 16 |
| `debug-test-errors` | Rule 11 |
| `handle-errors-in-code` | Rule 9 |
| `handle-secrets` | Rule 19 |
| `handle-user-output` | Rule 10 |
| `implement-domain-types` | Rule 3 |
| `organize-rust-modules` | Rule 13 |
| `place-code-in-ddd-layers` | Rule 2 |
| `work-with-tera-templates` | Rule 7 |
| `write-markdown-docs` | Rule 15 |

Rules 4, 5, 6, 12, 18, 20 were removed as duplicates of existing skills (`create-feature-branch`, `commit-changes`, `run-pre-commit-checks`, `create-adr`, `write-unit-test`, `create-environment-config`).

### AGENTS.md

- **Essential Rules**: 20 rules → 2 slim rules (~100 tokens total vs ~3000 before)
- **Skills table**: Expanded from 20 to 32 entries, alphabetically sorted

## Testing

- All linters pass (`cargo run --bin linter all`)
- All pre-commit checks pass (`./scripts/pre-commit.sh`)
