### PR TITLE
feat: add JSON output to validate command (12.10)

### DIFF
--- a/docs/user-guide/commands/validate.md
+++ b/docs/user-guide/commands/validate.md
@@ -77,6 +77,38 @@ Environment Details:
 • Backups: Enabled
 ```
 
+### JSON Output
+
+Use `--output-format json` (or `-o json`) to get machine-readable output. Progress messages go to stderr; the JSON result goes to stdout.
+
+```bash
+torrust-tracker-deployer validate --env-file envs/my-environment.json --output-format json 2>/dev/null
+```
+
+```json
+{
+  "environment_name": "my-environment",
+  "config_file": "envs/my-environment.json",
+  "provider": "lxd",
+  "is_valid": true,
+  "has_prometheus": true,
+  "has_grafana": true,
+  "has_https": false,
+  "has_backup": false
+}
+```
+
+| Field              | Type    | Description                                                     |
+| ------------------ | ------- | --------------------------------------------------------------- |
+| `environment_name` | string  | Name of the validated environment                               |
+| `config_file`      | string  | Path to the validated configuration file                        |
+| `provider`         | string  | Infrastructure provider (lowercase: `"lxd"`, `"hetzner"`, etc.) |
+| `is_valid`         | boolean | Always `true` when the command succeeds                         |
+| `has_prometheus`   | boolean | Whether Prometheus monitoring is configured                     |
+| `has_grafana`      | boolean | Whether Grafana dashboard is configured                         |
+| `has_https`        | boolean | Whether HTTPS is configured                                     |
+| `has_backup`       | boolean | Whether backups are configured                                  |
+
 ### Error Output Examples
 
 **File Not Found**:

--- a/src/presentation/cli/dispatch/router.rs
+++ b/src/presentation/cli/dispatch/router.rs
@@ -158,10 +158,11 @@ pub async fn route_command(
             Ok(())
         }
         Commands::Validate { env_file } => {
+            let output_format = context.output_format();
             context
                 .container()
                 .create_validate_controller()
-                .execute(&env_file)?;
+                .execute(&env_file, output_format)?;
             Ok(())
         }
         Commands::Register {

--- a/src/presentation/cli/views/commands/mod.rs
+++ b/src/presentation/cli/views/commands/mod.rs
@@ -14,3 +14,4 @@ pub mod run;
 pub mod shared;
 pub mod show;
 pub mod test;
+pub mod validate;

--- a/src/presentation/cli/views/commands/validate/mod.rs
+++ b/src/presentation/cli/views/commands/validate/mod.rs
@@ -1,0 +1,52 @@
+//! Views for Validate Command
+//!
+//! This module contains view components for rendering validate command output.
+//!
+//! # Architecture
+//!
+//! This module follows the Strategy Pattern for rendering:
+//! - `ValidateDetailsData`: The data DTO passed to all views
+//! - `TextView`: Renders human-readable text output
+//! - `JsonView`: Renders machine-readable JSON output
+//!
+//! # Structure
+//!
+//! - `view_data/`: Data structures (DTOs) passed to views
+//!   - `validate_details.rs`: Main DTO with validation result data
+//! - `views/`: View rendering implementations
+//!   - `text_view.rs`: Human-readable text rendering
+//!   - `json_view.rs`: Machine-readable JSON rendering
+//!
+//! # SOLID Principles
+//!
+//! - **Single Responsibility**: Each view has one job - render in its format
+//! - **Open/Closed**: Add new formats by creating new view files, not modifying existing ones
+//! - **Strategy Pattern**: Different rendering strategies for the same data
+//!
+//! # Adding New Formats
+//!
+//! To add a new output format (e.g., XML, YAML, CSV):
+//! 1. Create a new file in `views/`: `xml_view.rs`, `yaml_view.rs`, etc.
+//! 2. Implement the view with `render(data: &ValidateDetailsData) -> String`
+//! 3. Export it from this module
+//! 4. No need to modify existing views or the DTO
+
+pub mod view_data {
+    pub mod validate_details;
+
+    // Re-export main types for convenience
+    pub use validate_details::ValidateDetailsData;
+}
+
+pub mod views {
+    pub mod json_view;
+    pub mod text_view;
+
+    // Re-export views for convenience
+    pub use json_view::JsonView;
+    pub use text_view::TextView;
+}
+
+// Re-export at module root for convenience
+pub use view_data::ValidateDetailsData;
+pub use views::{JsonView, TextView};

--- a/src/presentation/cli/views/commands/validate/view_data/validate_details.rs
+++ b/src/presentation/cli/views/commands/validate/view_data/validate_details.rs
@@ -1,0 +1,156 @@
+//! Validate Details Data Transfer Object
+//!
+//! This module contains the presentation DTO for validate command details.
+//! It serves as the data structure passed to view renderers (`TextView`, `JsonView`, etc.).
+//!
+//! # Architecture
+//!
+//! This follows the Strategy Pattern where:
+//! - This DTO is the data passed to all rendering strategies
+//! - Different views (`TextView`, `JsonView`) consume this data
+//! - Adding new formats doesn't modify this DTO or existing views
+//!
+//! # SOLID Principles
+//!
+//! - **Single Responsibility**: This file only defines the data structure
+//! - **Open/Closed**: New formats extend by adding views, not modifying this
+//! - **Separation of Concerns**: Data definition separate from rendering logic
+
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::application::command_handlers::validate::ValidationResult;
+
+/// Validate details data for rendering
+///
+/// This struct holds all the data needed to render validate command
+/// information for display to the user. It is consumed by view renderers
+/// (`TextView`, `JsonView`) which format it according to their specific output format.
+///
+/// # Design
+///
+/// This is a presentation layer DTO (Data Transfer Object) that:
+/// - Decouples application types from view formatting
+/// - Provides a stable interface for multiple view strategies
+/// - Contains all fields needed for any output format
+///
+/// # Named Constructor vs `From`
+///
+/// Unlike domain-backed DTOs (which use `From<&Environment<State>>`),
+/// `ValidateDetailsData` combines two inputs (`&Path` + `&ValidationResult`).
+/// A named constructor `from_result` is used instead of `From` to keep the API clear.
+#[allow(clippy::struct_excessive_bools)] // Intentional: presentation data with feature flags
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ValidateDetailsData {
+    /// Name of the validated environment
+    pub environment_name: String,
+    /// Path to the validated configuration file (as displayed to the user)
+    pub config_file: String,
+    /// Infrastructure provider (lowercase: "lxd", "hetzner", etc.)
+    pub provider: String,
+    /// Always `true` when the command exits successfully
+    pub is_valid: bool,
+    /// Whether Prometheus monitoring is configured
+    pub has_prometheus: bool,
+    /// Whether Grafana dashboard is configured
+    pub has_grafana: bool,
+    /// Whether HTTPS is configured
+    pub has_https: bool,
+    /// Whether backups are configured
+    pub has_backup: bool,
+}
+
+impl ValidateDetailsData {
+    /// Construct a `ValidateDetailsData` from an env file path and validation result
+    ///
+    /// # Arguments
+    ///
+    /// * `env_file` - Path to the configuration file that was validated
+    /// * `result` - Successful validation result from the application layer
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::path::Path;
+    /// use torrust_tracker_deployer_lib::presentation::cli::views::commands::validate::ValidateDetailsData;
+    /// use torrust_tracker_deployer_lib::application::command_handlers::validate::ValidationResult;
+    ///
+    /// let result = ValidationResult {
+    ///     environment_name: "my-env".to_string(),
+    ///     provider: "lxd".to_string(),
+    ///     has_prometheus: true,
+    ///     has_grafana: false,
+    ///     has_https: false,
+    ///     has_backup: false,
+    /// };
+    ///
+    /// let data = ValidateDetailsData::from_result(Path::new("envs/my-env.json"), &result);
+    ///
+    /// assert_eq!(data.environment_name, "my-env");
+    /// assert_eq!(data.is_valid, true);
+    /// ```
+    #[must_use]
+    pub fn from_result(env_file: &Path, result: &ValidationResult) -> Self {
+        Self {
+            environment_name: result.environment_name.clone(),
+            config_file: env_file.display().to_string(),
+            provider: result.provider.clone(),
+            is_valid: true,
+            has_prometheus: result.has_prometheus,
+            has_grafana: result.has_grafana,
+            has_https: result.has_https,
+            has_backup: result.has_backup,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_sample_result() -> ValidationResult {
+        ValidationResult {
+            environment_name: "test-env".to_string(),
+            provider: "lxd".to_string(),
+            has_prometheus: true,
+            has_grafana: false,
+            has_https: false,
+            has_backup: true,
+        }
+    }
+
+    #[test]
+    fn it_should_build_dto_from_result() {
+        // Arrange
+        let result = create_sample_result();
+        let path = Path::new("envs/test-env.json");
+
+        // Act
+        let data = ValidateDetailsData::from_result(path, &result);
+
+        // Assert
+        assert_eq!(data.environment_name, "test-env");
+        assert_eq!(data.config_file, "envs/test-env.json");
+        assert_eq!(data.provider, "lxd");
+        assert!(data.is_valid);
+        assert!(data.has_prometheus);
+        assert!(!data.has_grafana);
+        assert!(!data.has_https);
+        assert!(data.has_backup);
+    }
+
+    #[test]
+    fn it_should_always_set_is_valid_to_true() {
+        // Arrange — no validation failure scenario can produce a ValidateDetailsData
+        // (only success paths call from_result)
+        let result = create_sample_result();
+        let path = Path::new("envs/test-env.json");
+
+        // Act
+        let data = ValidateDetailsData::from_result(path, &result);
+
+        // Assert
+        assert!(data.is_valid, "is_valid must always be true");
+    }
+}

--- a/src/presentation/cli/views/commands/validate/views/json_view.rs
+++ b/src/presentation/cli/views/commands/validate/views/json_view.rs
@@ -1,0 +1,285 @@
+//! JSON View for Validate Command
+//!
+//! This module provides JSON-based rendering for the validate command.
+//! It follows the Strategy Pattern, providing a machine-readable output format
+//! for the same underlying data (`ValidateDetailsData` DTO).
+//!
+//! # Design
+//!
+//! The `JsonView` serializes validation result information to JSON using `serde_json`.
+//! The output includes the environment name, configuration file path, provider,
+//! and feature flags for the validated configuration.
+
+use crate::presentation::cli::views::commands::validate::ValidateDetailsData;
+
+/// View for rendering validate details as JSON
+///
+/// This view provides machine-readable JSON output for automation workflows
+/// and AI agents. It serializes the validation details without any transformations,
+/// preserving all field names and structure from the DTO.
+///
+/// # Examples
+///
+/// ```rust
+/// use torrust_tracker_deployer_lib::presentation::cli::views::commands::validate::{
+///     ValidateDetailsData, JsonView,
+/// };
+///
+/// let data = ValidateDetailsData {
+///     environment_name: "my-env".to_string(),
+///     config_file: "envs/my-env.json".to_string(),
+///     provider: "lxd".to_string(),
+///     is_valid: true,
+///     has_prometheus: true,
+///     has_grafana: false,
+///     has_https: false,
+///     has_backup: false,
+/// };
+///
+/// let output = JsonView::render(&data);
+///
+/// // Verify it's valid JSON
+/// let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+/// assert_eq!(parsed["environment_name"], "my-env");
+/// assert_eq!(parsed["is_valid"], true);
+/// ```
+pub struct JsonView;
+
+impl JsonView {
+    /// Render validate details as JSON
+    ///
+    /// Serializes the validation details to pretty-printed JSON format.
+    /// The JSON structure matches the DTO structure exactly:
+    /// - `environment_name`: Name of the validated environment
+    /// - `config_file`: Path to the validated configuration file
+    /// - `provider`: Infrastructure provider (lowercase)
+    /// - `is_valid`: Always `true` on success
+    /// - `has_prometheus`: Whether Prometheus is configured
+    /// - `has_grafana`: Whether Grafana is configured
+    /// - `has_https`: Whether HTTPS is configured
+    /// - `has_backup`: Whether backups are configured
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - Validate details to render
+    ///
+    /// # Returns
+    ///
+    /// A JSON string containing the serialized validate details.
+    /// If serialization fails (which should never happen with valid data),
+    /// returns an error JSON object with the serialization error message.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use torrust_tracker_deployer_lib::presentation::cli::views::commands::validate::{
+    ///     ValidateDetailsData, JsonView,
+    /// };
+    ///
+    /// let data = ValidateDetailsData {
+    ///     environment_name: "prod-tracker".to_string(),
+    ///     config_file: "envs/prod-tracker.json".to_string(),
+    ///     provider: "lxd".to_string(),
+    ///     is_valid: true,
+    ///     has_prometheus: true,
+    ///     has_grafana: true,
+    ///     has_https: true,
+    ///     has_backup: false,
+    /// };
+    ///
+    /// let json = JsonView::render(&data);
+    ///
+    /// assert!(json.contains("\"environment_name\": \"prod-tracker\""));
+    /// assert!(json.contains("\"is_valid\": true"));
+    /// ```
+    #[must_use]
+    pub fn render(data: &ValidateDetailsData) -> String {
+        serde_json::to_string_pretty(data).unwrap_or_else(|e| {
+            format!(
+                r#"{{
+  "error": "Failed to serialize validate details",
+  "message": "{e}"
+}}"#
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test fixtures
+
+    fn create_test_data() -> ValidateDetailsData {
+        ValidateDetailsData {
+            environment_name: "test-env".to_string(),
+            config_file: "envs/test-env.json".to_string(),
+            provider: "lxd".to_string(),
+            is_valid: true,
+            has_prometheus: true,
+            has_grafana: false,
+            has_https: false,
+            has_backup: true,
+        }
+    }
+
+    /// Helper to assert JSON fields match expected string values
+    fn assert_json_str_fields_eq(json: &str, expected_fields: &[(&str, &str)]) {
+        let parsed: serde_json::Value = serde_json::from_str(json).expect("Should be valid JSON");
+        for (field, expected_value) in expected_fields {
+            assert_eq!(
+                parsed[field].as_str().unwrap_or(""),
+                *expected_value,
+                "Field '{field}' should be '{expected_value}'"
+            );
+        }
+    }
+
+    /// Helper to assert JSON bool fields match expected values
+    fn assert_json_bool_fields_eq(json: &str, expected_fields: &[(&str, bool)]) {
+        let parsed: serde_json::Value = serde_json::from_str(json).expect("Should be valid JSON");
+        for (field, expected_value) in expected_fields {
+            assert_eq!(
+                parsed[field].as_bool().unwrap_or(false),
+                *expected_value,
+                "Field '{field}' should be '{expected_value}'"
+            );
+        }
+    }
+
+    /// Helper to assert JSON contains all required field names
+    fn assert_json_has_fields(json: &str, field_names: &[&str]) {
+        let parsed: serde_json::Value = serde_json::from_str(json).expect("Should be valid JSON");
+        for field_name in field_names {
+            assert!(
+                parsed.get(field_name).is_some(),
+                "Expected JSON to have field '{field_name}' but it didn't.\nActual JSON:\n{json}"
+            );
+        }
+    }
+
+    // Tests
+
+    #[test]
+    fn it_should_render_validate_details_as_valid_json() {
+        // Arrange
+        let data = create_test_data();
+
+        // Act
+        let json = JsonView::render(&data);
+
+        // Assert - verify it's valid JSON with expected string field values
+        assert_json_str_fields_eq(
+            &json,
+            &[
+                ("environment_name", "test-env"),
+                ("config_file", "envs/test-env.json"),
+                ("provider", "lxd"),
+            ],
+        );
+    }
+
+    #[test]
+    fn it_should_render_boolean_fields_correctly() {
+        // Arrange
+        let data = create_test_data();
+
+        // Act
+        let json = JsonView::render(&data);
+
+        // Assert
+        assert_json_bool_fields_eq(
+            &json,
+            &[
+                ("is_valid", true),
+                ("has_prometheus", true),
+                ("has_grafana", false),
+                ("has_https", false),
+                ("has_backup", true),
+            ],
+        );
+    }
+
+    #[test]
+    fn it_should_include_all_required_fields() {
+        // Arrange
+        let data = create_test_data();
+
+        // Act
+        let json = JsonView::render(&data);
+
+        // Assert - check all required fields are present
+        assert_json_has_fields(
+            &json,
+            &[
+                "environment_name",
+                "config_file",
+                "provider",
+                "is_valid",
+                "has_prometheus",
+                "has_grafana",
+                "has_https",
+                "has_backup",
+            ],
+        );
+    }
+
+    #[test]
+    fn it_should_render_all_features_enabled() {
+        // Arrange
+        let data = ValidateDetailsData {
+            environment_name: "full-stack".to_string(),
+            config_file: "envs/full-stack.json".to_string(),
+            provider: "lxd".to_string(),
+            is_valid: true,
+            has_prometheus: true,
+            has_grafana: true,
+            has_https: true,
+            has_backup: true,
+        };
+
+        // Act
+        let json = JsonView::render(&data);
+
+        // Assert
+        assert_json_bool_fields_eq(
+            &json,
+            &[
+                ("has_prometheus", true),
+                ("has_grafana", true),
+                ("has_https", true),
+                ("has_backup", true),
+            ],
+        );
+    }
+
+    #[test]
+    fn it_should_render_all_features_disabled() {
+        // Arrange
+        let data = ValidateDetailsData {
+            environment_name: "minimal-env".to_string(),
+            config_file: "envs/minimal-env.json".to_string(),
+            provider: "lxd".to_string(),
+            is_valid: true,
+            has_prometheus: false,
+            has_grafana: false,
+            has_https: false,
+            has_backup: false,
+        };
+
+        // Act
+        let json = JsonView::render(&data);
+
+        // Assert
+        assert_json_bool_fields_eq(
+            &json,
+            &[
+                ("has_prometheus", false),
+                ("has_grafana", false),
+                ("has_https", false),
+                ("has_backup", false),
+            ],
+        );
+    }
+}

--- a/src/presentation/cli/views/commands/validate/views/text_view.rs
+++ b/src/presentation/cli/views/commands/validate/views/text_view.rs
@@ -1,0 +1,281 @@
+//! Text View for Validate Command
+//!
+//! This module provides text-based rendering for the validate command.
+//! It follows the Strategy Pattern, providing a human-readable output format
+//! for the same underlying data (`ValidateDetailsData` DTO).
+//!
+//! # Design
+//!
+//! The `TextView` formats validation details as human-readable text suitable
+//! for terminal display and direct user consumption. It preserves the exact
+//! output format produced before the Strategy Pattern was introduced.
+
+use crate::presentation::cli::views::commands::validate::ValidateDetailsData;
+
+/// View for rendering validate details as human-readable text
+///
+/// This view produces formatted text output suitable for terminal display
+/// and human consumption. It presents environment validation details
+/// in a clear, readable format.
+///
+/// The rendered string is intended to be passed to `ProgressReporter::complete()`,
+/// which adds the `✅` prefix to the first line.
+///
+/// # Examples
+///
+/// ```rust
+/// use torrust_tracker_deployer_lib::presentation::cli::views::commands::validate::{
+///     ValidateDetailsData, TextView,
+/// };
+///
+/// let data = ValidateDetailsData {
+///     environment_name: "my-env".to_string(),
+///     config_file: "envs/my-env.json".to_string(),
+///     provider: "lxd".to_string(),
+///     is_valid: true,
+///     has_prometheus: true,
+///     has_grafana: false,
+///     has_https: false,
+///     has_backup: false,
+/// };
+///
+/// let output = TextView::render(&data);
+/// assert!(output.contains("Configuration file 'envs/my-env.json' is valid"));
+/// assert!(output.contains("Environment Details:"));
+/// assert!(output.contains("my-env"));
+/// ```
+pub struct TextView;
+
+impl TextView {
+    /// Render validate details as human-readable formatted text
+    ///
+    /// Takes validation details and produces a human-readable output
+    /// intended to be wrapped by `ProgressReporter::complete()`.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - Validate details to render
+    ///
+    /// # Returns
+    ///
+    /// A formatted string containing:
+    /// - First line: "Configuration file '`<path>`' is valid"
+    /// - Blank line separator
+    /// - "Environment Details:" section with name, provider, and feature flags
+    ///
+    /// # Format
+    ///
+    /// The output follows this structure:
+    /// ```text
+    /// Configuration file '`<config_file>`' is valid
+    ///
+    /// Environment Details:
+    /// • Name: <environment_name>
+    /// • Provider: <provider>
+    /// • Prometheus: Enabled|Disabled
+    /// • Grafana: Enabled|Disabled
+    /// • HTTPS: Enabled|Disabled
+    /// • Backups: Enabled|Disabled
+    /// ```
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use torrust_tracker_deployer_lib::presentation::cli::views::commands::validate::{
+    ///     ValidateDetailsData, TextView,
+    /// };
+    ///
+    /// let data = ValidateDetailsData {
+    ///     environment_name: "prod-tracker".to_string(),
+    ///     config_file: "envs/prod-tracker.json".to_string(),
+    ///     provider: "lxd".to_string(),
+    ///     is_valid: true,
+    ///     has_prometheus: true,
+    ///     has_grafana: true,
+    ///     has_https: false,
+    ///     has_backup: false,
+    /// };
+    ///
+    /// let text = TextView::render(&data);
+    ///
+    /// assert!(text.contains("Configuration file 'envs/prod-tracker.json' is valid"));
+    /// assert!(text.contains("Name:"));
+    /// assert!(text.contains("prod-tracker"));
+    /// ```
+    #[must_use]
+    pub fn render(data: &ValidateDetailsData) -> String {
+        format!(
+            "Configuration file '{}' is valid\n\nEnvironment Details:\n\
+            • Name: {}\n\
+            • Provider: {}\n\
+            • Prometheus: {}\n\
+            • Grafana: {}\n\
+            • HTTPS: {}\n\
+            • Backups: {}",
+            data.config_file,
+            data.environment_name,
+            data.provider,
+            if data.has_prometheus {
+                "Enabled"
+            } else {
+                "Disabled"
+            },
+            if data.has_grafana {
+                "Enabled"
+            } else {
+                "Disabled"
+            },
+            if data.has_https {
+                "Enabled"
+            } else {
+                "Disabled"
+            },
+            if data.has_backup {
+                "Enabled"
+            } else {
+                "Disabled"
+            }
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test fixtures
+
+    fn create_test_data_all_enabled() -> ValidateDetailsData {
+        ValidateDetailsData {
+            environment_name: "test-env".to_string(),
+            config_file: "envs/test-env.json".to_string(),
+            provider: "lxd".to_string(),
+            is_valid: true,
+            has_prometheus: true,
+            has_grafana: true,
+            has_https: true,
+            has_backup: true,
+        }
+    }
+
+    fn create_test_data_all_disabled() -> ValidateDetailsData {
+        ValidateDetailsData {
+            environment_name: "minimal-env".to_string(),
+            config_file: "envs/minimal-env.json".to_string(),
+            provider: "lxd".to_string(),
+            is_valid: true,
+            has_prometheus: false,
+            has_grafana: false,
+            has_https: false,
+            has_backup: false,
+        }
+    }
+
+    /// Helper to assert text contains all expected substrings
+    fn assert_contains_all(text: &str, expected: &[&str]) {
+        for substring in expected {
+            assert!(
+                text.contains(substring),
+                "Expected text to contain '{substring}' but it didn't.\nActual text:\n{text}"
+            );
+        }
+    }
+
+    // Tests
+
+    #[test]
+    fn it_should_render_validate_details_as_formatted_text() {
+        // Arrange
+        let data = create_test_data_all_enabled();
+
+        // Act
+        let text = TextView::render(&data);
+
+        // Assert
+        assert_contains_all(
+            &text,
+            &[
+                "Configuration file 'envs/test-env.json' is valid",
+                "Environment Details:",
+                "Name:",
+                "test-env",
+                "Provider:",
+                "lxd",
+                "Prometheus:",
+                "Grafana:",
+                "HTTPS:",
+                "Backups:",
+            ],
+        );
+    }
+
+    #[test]
+    fn it_should_display_enabled_when_features_are_configured() {
+        // Arrange
+        let data = create_test_data_all_enabled();
+
+        // Act
+        let text = TextView::render(&data);
+
+        // Assert - all feature sections show "Enabled"
+        let enabled_count = text.matches("Enabled").count();
+        assert_eq!(
+            enabled_count, 4,
+            "Expected 4 'Enabled' occurrences (prometheus, grafana, https, backup) but got {enabled_count}\nText: {text}"
+        );
+    }
+
+    #[test]
+    fn it_should_display_disabled_when_features_are_not_configured() {
+        // Arrange
+        let data = create_test_data_all_disabled();
+
+        // Act
+        let text = TextView::render(&data);
+
+        // Assert - all feature sections show "Disabled"
+        let disabled_count = text.matches("Disabled").count();
+        assert_eq!(
+            disabled_count, 4,
+            "Expected 4 'Disabled' occurrences (prometheus, grafana, https, backup) but got {disabled_count}\nText: {text}"
+        );
+    }
+
+    #[test]
+    fn it_should_include_config_file_path_in_first_line() {
+        // Arrange
+        let data = create_test_data_all_disabled();
+
+        // Act
+        let text = TextView::render(&data);
+
+        // Assert
+        assert!(
+            text.starts_with("Configuration file 'envs/minimal-env.json' is valid"),
+            "Text should start with config file path validation message.\nActual:\n{text}"
+        );
+    }
+
+    #[test]
+    fn it_should_include_all_required_sections() {
+        // Arrange
+        let data = create_test_data_all_enabled();
+
+        // Act
+        let text = TextView::render(&data);
+
+        // Assert
+        assert_contains_all(
+            &text,
+            &[
+                "Environment Details:",
+                "• Name:",
+                "• Provider:",
+                "• Prometheus:",
+                "• Grafana:",
+                "• HTTPS:",
+                "• Backups:",
+            ],
+        );
+    }
+}


### PR DESCRIPTION
## Overview

Closes #390 — Part of EPIC #348 (roadmap task 12.10).

Adds JSON output format support to the `validate` command. When `--output-format json` is passed, the command outputs a machine-readable JSON object to stdout. The existing human-readable text output is fully preserved.

## Changes

### New files

- `src/presentation/cli/views/commands/validate/mod.rs` — module declaration
- `src/presentation/cli/views/commands/validate/view_data/validate_details.rs` — `ValidateDetailsData` DTO with `from_result(&Path, &ValidationResult)` constructor
- `src/presentation/cli/views/commands/validate/views/json_view.rs` — `JsonView` with unit tests
- `src/presentation/cli/views/commands/validate/views/text_view.rs` — `TextView` with unit tests

### Modified files

- `src/presentation/cli/controllers/validate/handler.rs` — add `output_format: OutputFormat` param to `execute()`, refactor `complete_workflow()` to dispatch to `TextView`/`JsonView`
- `src/presentation/cli/dispatch/router.rs` — pass `context.output_format()` to controller
- `src/presentation/cli/views/commands/mod.rs` — register `pub mod validate`
- `docs/user-guide/commands/validate.md` — add JSON output section

## JSON Output

```bash
cargo run -- validate --env-file envs/lxd-local-example.json --output-format json 2>/dev/null
```

```json
{
  "environment_name": "lxd-local-example",
  "config_file": "envs/lxd-local-example.json",
  "provider": "lxd",
  "is_valid": true,
  "has_prometheus": true,
  "has_grafana": true,
  "has_https": false,
  "has_backup": false
}
```

## Text Output (unchanged)

```bash
cargo run -- validate --env-file envs/lxd-local-example.json 2>&1
```

```text
⏳ [1/3] Loading configuration file...
⏳   ✓ Configuration file loaded (took 0ms)
⏳ [2/3] Validating JSON schema...
⏳   ✓ Schema validation passed (took 0ms)
⏳ [3/3] Validating configuration fields...
⏳   ✓ Field validation passed (took 0ms)

✅ Configuration file 'envs/lxd-local-example.json' is valid

Environment Details:
• Name: lxd-local-example
• Provider: lxd
• Prometheus: Enabled
• Grafana: Enabled
• HTTPS: Disabled
• Backups: Disabled
```

## Quality Checks

- [x] `cargo run --bin linter all` passes (stable + nightly)
- [x] `cargo machete` — no unused dependencies
- [x] `cargo test` — 417 tests pass, 0 failures
- [x] Text output manually verified identical to pre-change output
- [x] JSON output manually verified matches spec

## Related

- Closes #390
- Parent epic: #348
- Spec: `docs/issues/390-add-json-output-to-validate-command.md`