### PR TITLE
fix: [#409] replace hardcoded /opt/torrust paths with deploy_dir variable in Ansible templates

### DIFF
--- a/templates/ansible/create-backup-storage.yml
+++ b/templates/ansible/create-backup-storage.yml
@@ -21,20 +21,23 @@
 # The directories are created with appropriate permissions and ownership.
 #
 # Directory Structure:
-# /opt/torrust/storage/backup/
+# {{ deploy_dir }}/storage/backup/
 # └── etc/              # Backup configuration files
 #
 # Variables:
+# - deploy_dir: Base deployment directory (from variables.yml)
 # - ansible_user: The SSH user for the remote host (set automatically)
 
 - name: Create Backup storage directories
   hosts: all
   become: true
+  vars_files:
+    - variables.yml
 
   tasks:
     - name: Create backup configuration directory
       ansible.builtin.file:
-        path: /opt/torrust/storage/backup/etc
+        path: "{{ deploy_dir }}/storage/backup/etc"
         state: directory
         mode: "0755"
         owner: "{{ ansible_user }}"
@@ -42,7 +45,7 @@
 
     - name: Verify backup configuration directory exists
       ansible.builtin.stat:
-        path: /opt/torrust/storage/backup/etc
+        path: "{{ deploy_dir }}/storage/backup/etc"
       register: backup_etc_dir
 
     - name: Assert backup directories were created

--- a/templates/ansible/create-prometheus-storage.yml
+++ b/templates/ansible/create-prometheus-storage.yml
@@ -20,6 +20,8 @@
 - name: Create Prometheus storage directories
   hosts: all
   become: true
+  vars_files:
+    - variables.yml
 
   tasks:
     - name: Create Prometheus directory structure
@@ -30,4 +32,4 @@
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
       loop:
-        - /opt/torrust/storage/prometheus/etc
+        - "{{ deploy_dir }}/storage/prometheus/etc"

--- a/templates/ansible/create-tracker-storage.yml
+++ b/templates/ansible/create-tracker-storage.yml
@@ -20,6 +20,8 @@
 - name: Create Tracker storage directories
   hosts: all
   become: true
+  vars_files:
+    - variables.yml
 
   tasks:
     - name: Create Tracker directory structure
@@ -30,6 +32,6 @@
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
       loop:
-        - /opt/torrust/storage/tracker/etc
-        - /opt/torrust/storage/tracker/lib/database
-        - /opt/torrust/storage/tracker/log
+        - "{{ deploy_dir }}/storage/tracker/etc"
+        - "{{ deploy_dir }}/storage/tracker/lib/database"
+        - "{{ deploy_dir }}/storage/tracker/log"

--- a/templates/ansible/deploy-backup-config.yml
+++ b/templates/ansible/deploy-backup-config.yml
@@ -32,12 +32,14 @@
 - name: Deploy Backup configuration
   hosts: all
   become: true
+  vars_files:
+    - variables.yml
 
   tasks:
     - name: Copy backup.conf to VM
       ansible.builtin.copy:
         src: "{{ playbook_dir }}/../backup/etc/backup.conf"
-        dest: /opt/torrust/storage/backup/etc/backup.conf
+        dest: "{{ deploy_dir }}/storage/backup/etc/backup.conf"
         mode: "0644"
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
@@ -45,19 +47,19 @@
     - name: Copy backup-paths.txt to VM
       ansible.builtin.copy:
         src: "{{ playbook_dir }}/../backup/etc/backup-paths.txt"
-        dest: /opt/torrust/storage/backup/etc/backup-paths.txt
+        dest: "{{ deploy_dir }}/storage/backup/etc/backup-paths.txt"
         mode: "0644"
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
 
     - name: Verify backup.conf exists
       ansible.builtin.stat:
-        path: /opt/torrust/storage/backup/etc/backup.conf
+        path: "{{ deploy_dir }}/storage/backup/etc/backup.conf"
       register: backup_conf
 
     - name: Verify backup-paths.txt exists
       ansible.builtin.stat:
-        path: /opt/torrust/storage/backup/etc/backup-paths.txt
+        path: "{{ deploy_dir }}/storage/backup/etc/backup-paths.txt"
       register: backup_paths
 
     - name: Assert backup configuration files were deployed

--- a/templates/ansible/deploy-caddy-config.yml
+++ b/templates/ansible/deploy-caddy-config.yml
@@ -28,13 +28,15 @@
 # - ansible_user: The SSH user for the remote host (set automatically)
 #
 # Storage Directories:
-# - /opt/torrust/storage/caddy/etc/ - Caddyfile configuration
-# - /opt/torrust/storage/caddy/data/ - Caddy data (certificates, etc.)
-# - /opt/torrust/storage/caddy/config/ - Caddy config state
+# - {{ deploy_dir }}/storage/caddy/etc/ - Caddyfile configuration
+# - {{ deploy_dir }}/storage/caddy/data/ - Caddy data (certificates, etc.)
+# - {{ deploy_dir }}/storage/caddy/config/ - Caddy config state
 
 - name: Deploy Caddy configuration
   hosts: all
   become: true
+  vars_files:
+    - variables.yml
 
   tasks:
     - name: Create Caddy storage directories
@@ -45,23 +47,23 @@
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
       loop:
-        - /opt/torrust/storage/caddy
-        - /opt/torrust/storage/caddy/etc
-        - /opt/torrust/storage/caddy/data
-        - /opt/torrust/storage/caddy/config
+        - "{{ deploy_dir }}/storage/caddy"
+        - "{{ deploy_dir }}/storage/caddy/etc"
+        - "{{ deploy_dir }}/storage/caddy/data"
+        - "{{ deploy_dir }}/storage/caddy/config"
 
     - name: Copy Caddyfile to VM
       ansible.builtin.copy:
         src: "{{ playbook_dir }}/../caddy/Caddyfile"
         # Note: This is the host path. Inside the container, it's mounted to /etc/caddy/Caddyfile
-        dest: /opt/torrust/storage/caddy/etc/Caddyfile
+        dest: "{{ deploy_dir }}/storage/caddy/etc/Caddyfile"
         mode: "0644"
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
 
     - name: Verify Caddy configuration file exists
       ansible.builtin.stat:
-        path: /opt/torrust/storage/caddy/etc/Caddyfile
+        path: "{{ deploy_dir }}/storage/caddy/etc/Caddyfile"
       register: caddy_config
 
     - name: Assert Caddy configuration was deployed

--- a/templates/ansible/deploy-compose-files.yml
+++ b/templates/ansible/deploy-compose-files.yml
@@ -21,19 +21,20 @@
   hosts: all
   gather_facts: false
   become: true
+  vars_files:
+    - variables.yml
 
   vars:
-    remote_deploy_dir: /opt/torrust
     local_compose_dir: "{{ compose_files_source_dir }}"
 
   tasks:
     - name: 📦 Starting Docker Compose files deployment
       ansible.builtin.debug:
-        msg: "🚀 Deploying Docker Compose files to {{ inventory_hostname }}:{{ remote_deploy_dir }}"
+        msg: "🚀 Deploying Docker Compose files to {{ inventory_hostname }}:{{ deploy_dir }}"
 
     - name: Ensure remote deployment directory exists
       ansible.builtin.file:
-        path: "{{ remote_deploy_dir }}"
+        path: "{{ deploy_dir }}"
         state: directory
         mode: "0755"
         owner: "{{ ansible_user }}"
@@ -42,7 +43,7 @@
     - name: Copy Docker Compose files to remote host
       ansible.builtin.copy:
         src: "{{ local_compose_dir }}/"
-        dest: "{{ remote_deploy_dir }}/"
+        dest: "{{ deploy_dir }}/"
         mode: "0640"
         directory_mode: "0755"
         owner: "{{ ansible_user }}"
@@ -50,17 +51,17 @@
 
     - name: Verify docker-compose.yml exists on remote
       ansible.builtin.stat:
-        path: "{{ remote_deploy_dir }}/docker-compose.yml"
+        path: "{{ deploy_dir }}/docker-compose.yml"
       register: compose_file_check
 
     - name: Fail if docker-compose.yml was not deployed
       ansible.builtin.fail:
-        msg: "docker-compose.yml was not found at {{ remote_deploy_dir }}/docker-compose.yml after deployment"
+        msg: "docker-compose.yml was not found at {{ deploy_dir }}/docker-compose.yml after deployment"
       when: not compose_file_check.stat.exists
 
     - name: List deployed files
       ansible.builtin.find:
-        paths: "{{ remote_deploy_dir }}"
+        paths: "{{ deploy_dir }}"
         file_type: file
         recurse: true
       register: deployed_files
@@ -69,8 +70,8 @@
       ansible.builtin.debug:
         msg: |
           ✅ Docker Compose files deployed successfully!
-          📁 Destination: {{ remote_deploy_dir }}
+          📁 Destination: {{ deploy_dir }}
           📄 Files deployed: {{ deployed_files.files | length }}
           {% for file in deployed_files.files %}
-          - {{ file.path | regex_replace(remote_deploy_dir ~ '/', '') }}
+          - {{ file.path | regex_replace(deploy_dir ~ '/', '') }}
           {% endfor %}

--- a/templates/ansible/deploy-prometheus-config.yml
+++ b/templates/ansible/deploy-prometheus-config.yml
@@ -31,20 +31,22 @@
 - name: Deploy Prometheus configuration
   hosts: all
   become: true
+  vars_files:
+    - variables.yml
 
   tasks:
     - name: Copy prometheus.yml to VM
       ansible.builtin.copy:
         src: "{{ playbook_dir }}/../prometheus/prometheus.yml"
         # Note: This is the host path. Inside the container, it's mounted to /etc/prometheus/
-        dest: /opt/torrust/storage/prometheus/etc/prometheus.yml
+        dest: "{{ deploy_dir }}/storage/prometheus/etc/prometheus.yml"
         mode: "0644"
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
 
     - name: Verify Prometheus configuration file exists
       ansible.builtin.stat:
-        path: /opt/torrust/storage/prometheus/etc/prometheus.yml
+        path: "{{ deploy_dir }}/storage/prometheus/etc/prometheus.yml"
       register: prometheus_config
 
     - name: Assert Prometheus configuration was deployed

--- a/templates/ansible/deploy-tracker-config.yml
+++ b/templates/ansible/deploy-tracker-config.yml
@@ -31,20 +31,22 @@
 - name: Deploy Tracker configuration
   hosts: all
   become: true
+  vars_files:
+    - variables.yml
 
   tasks:
     - name: Copy tracker.toml to VM
       ansible.builtin.copy:
         src: "{{ playbook_dir }}/../tracker/tracker.toml"
         # Note: This is the host path. Inside the container, it's mounted to /var/lib/torrust/tracker/etc/
-        dest: /opt/torrust/storage/tracker/etc/tracker.toml
+        dest: "{{ deploy_dir }}/storage/tracker/etc/tracker.toml"
         mode: "0644"
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
 
     - name: Verify tracker configuration file exists
       ansible.builtin.stat:
-        path: /opt/torrust/storage/tracker/etc/tracker.toml
+        path: "{{ deploy_dir }}/storage/tracker/etc/tracker.toml"
       register: tracker_config
 
     - name: Assert tracker configuration was deployed

--- a/templates/ansible/init-tracker-database.yml
+++ b/templates/ansible/init-tracker-database.yml
@@ -22,21 +22,23 @@
 #
 # Requirements:
 #   - The tracker storage directories must exist
-#   - The ansible_user must have write access to /opt/torrust/storage/tracker/lib/database/
+#   - The ansible_user must have write access to {{ deploy_dir }}/storage/tracker/lib/database/
 #
 # Variables:
 #   - ansible_user: The user that will own the database file (default: current user)
 #
 # Creates:
-#   - /opt/torrust/storage/tracker/lib/database/tracker.db (SQLite database file)
+#   - {{ deploy_dir }}/storage/tracker/lib/database/tracker.db (SQLite database file)
 
 - name: Initialize Tracker Database
   hosts: all
   become: true
+  vars_files:
+    - variables.yml
   tasks:
     - name: Create empty SQLite database file
       ansible.builtin.file:
-        path: /opt/torrust/storage/tracker/lib/database/tracker.db
+        path: "{{ deploy_dir }}/storage/tracker/lib/database/tracker.db"
         state: touch
         owner: "{{ ansible_user }}"
         group: "{{ ansible_user }}"
@@ -46,7 +48,7 @@
 
     - name: Verify database file exists
       ansible.builtin.stat:
-        path: /opt/torrust/storage/tracker/lib/database/tracker.db
+        path: "{{ deploy_dir }}/storage/tracker/lib/database/tracker.db"
       register: db_file
 
     - name: Assert database file was created

--- a/templates/ansible/run-compose-services.yml
+++ b/templates/ansible/run-compose-services.yml
@@ -21,9 +21,8 @@
   hosts: all
   gather_facts: false
   become: true
-
-  vars:
-    deploy_dir: /opt/torrust
+  vars_files:
+    - variables.yml
 
   tasks:
     - name: 🚀 Starting Docker Compose services


### PR DESCRIPTION
## Summary

Fixes #409 — Several Ansible playbook templates under `templates/ansible/` were hardcoding the deployment directory as `/opt/torrust` instead of using the `{{ deploy_dir }}` variable from `variables.yml`. This caused deployment failures when a custom deployment directory was configured.

## Changes

### Phase 1: Fix fully hardcoded templates

All the following templates had `vars_files: [variables.yml]` added and all hardcoded `/opt/torrust` paths replaced with `{{ deploy_dir }}`:

- `templates/ansible/create-tracker-storage.yml` — 3 loop items
- `templates/ansible/create-prometheus-storage.yml` — 1 loop item
- `templates/ansible/create-backup-storage.yml` — 2 `path:` params
- `templates/ansible/deploy-backup-config.yml` — 4 `dest:` and `path:` params
- `templates/ansible/deploy-tracker-config.yml` — 2 `dest:` and `path:` params
- `templates/ansible/deploy-prometheus-config.yml` — 2 `dest:` and `path:` params
- `templates/ansible/init-tracker-database.yml` — 2 `path:` params
- `templates/ansible/deploy-caddy-config.yml` — 6 loop items + `dest:` + `path:`

### Phase 2: Fix inline-variable templates

- `templates/ansible/run-compose-services.yml` — Removed inline `vars: deploy_dir: /opt/torrust`; added `vars_files: [variables.yml]`
- `templates/ansible/deploy-compose-files.yml` — Removed inline `vars: remote_deploy_dir: /opt/torrust`; added `vars_files: [variables.yml]`; renamed all `remote_deploy_dir` references to `deploy_dir`

### Phase 3: Update comments

Updated inline comments in modified templates to reference `{{ deploy_dir }}` instead of `/opt/torrust` example paths.

## Acceptance Criteria

- [x] No playbook task in `templates/ansible/` uses a hardcoded `/opt/torrust` path in `path:`, `dest:`, or loop items
- [x] All playbooks that reference the deployment directory load `variables.yml` via `vars_files`
- [x] The variable name `deploy_dir` is used consistently (no `remote_deploy_dir` or other aliases)
- [x] Playbooks that previously had inline `vars:` blocks for the deploy directory no longer define it inline
- [x] The default behavior (with `deploy_dir: /opt/torrust`) is unchanged
- [x] YAML linter passes (`cargo run --bin linter yaml`)
- [x] Markdown linter passes
- [x] Spell checker passes