### PR TITLE
ci: upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/backup-container.yaml
+++ b/.github/workflows/backup-container.yaml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -141,7 +141,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Docker Meta
         id: meta
@@ -184,7 +184,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Docker Meta
         id: meta

--- a/.github/workflows/code-statistics.yml
+++ b/.github/workflows/code-statistics.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install tokei
         run: cargo install tokei

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -132,7 +132,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Docker Meta
         id: meta
@@ -175,7 +175,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Docker Meta
         id: meta

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - id: setup
         name: Setup Toolchain
@@ -54,7 +54,7 @@ jobs:
 
       - id: upload-coverage
         name: Upload HTML Coverage Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-html-report
           path: target/llvm-cov/html/

--- a/.github/workflows/docker-security-scan.yml
+++ b/.github/workflows/docker-security-scan.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Build images locally so Trivy scans exactly
       # what this repository produces
@@ -86,7 +86,7 @@ jobs:
           scanners: "vuln"
 
       - name: Upload SARIF artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: sarif-project-${{ matrix.image.name }}-${{ github.run_id }}
@@ -140,7 +140,7 @@ jobs:
           echo "name=$(echo '${{ matrix.image }}' | tr '/:' '-')" >> "$GITHUB_OUTPUT"
 
       - name: Upload SARIF artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: sarif-third-party-${{ steps.sanitize.outputs.name }}-${{ github.run_id }}
@@ -162,7 +162,7 @@ jobs:
 
     steps:
       - name: Download all SARIF artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: sarif-*-${{ github.run_id }}
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -23,11 +23,11 @@ jobs:
 
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - id: node
         name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
 

--- a/.github/workflows/test-dependency-installer.yml
+++ b/.github/workflows/test-dependency-installer.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/test-e2e-deployment.yml
+++ b/.github/workflows/test-e2e-deployment.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Tune GitHub hosted runner network
         uses: smorimoto/tune-github-hosted-runner-network@v1

--- a/.github/workflows/test-e2e-infrastructure.yml
+++ b/.github/workflows/test-e2e-infrastructure.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Tune GitHub-hosted runner network
         uses: smorimoto/tune-github-hosted-runner-network@v1

--- a/.github/workflows/test-lxd-provision.yml
+++ b/.github/workflows/test-lxd-provision.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Tune GitHub-hosted runner network
         uses: smorimoto/tune-github-hosted-runner-network@v1

--- a/.github/workflows/test-sdk-examples.yml
+++ b/.github/workflows/test-sdk-examples.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - id: setup
         name: Setup Toolchain
@@ -40,7 +40,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - id: setup
         name: Setup Toolchain
@@ -139,7 +139,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - id: setup
         name: Setup Toolchain


### PR DESCRIPTION
## Summary

Upgrades GitHub Actions across all 13 workflow files to versions that run on Node.js 24, resolving deprecation warnings.

Node.js 20 is EOL in April 2026. Runners will default to Node.js 24 starting **June 2nd, 2026**, and Node.js 20 will be fully removed in fall 2026.

## Changes

| Action | Old | New |
|---|---|---|
| `actions/checkout` | `@v4` (Node 20) | `@v5` (Node 24) |
| `actions/upload-artifact` | `@v4` (Node 20) | `@v6` (Node 24) |
| `actions/download-artifact` | `@v4` (Node 20) | `@v7` (Node 24) |
| `actions/setup-node` | `@v4` (Node 20) | `@v5` (Node 24) |

## Affected Workflows

- `backup-container.yaml`
- `code-statistics.yml`
- `container.yaml`
- `copilot-setup-steps.yml`
- `coverage.yml`
- `docker-security-scan.yml`
- `linting.yml`
- `test-dependency-installer.yml`
- `test-e2e-deployment.yml`
- `test-e2e-infrastructure.yml`
- `test-lxd-provision.yml`
- `test-sdk-examples.yml`
- `testing.yml`

## Notes

The `actions/cache` deprecation warning inside `aquasecurity/trivy-action` cannot be fixed here — it is an internal dependency managed by Aqua Security and will be resolved when they release an updated version.

## Reference

- [Deprecation of Node 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)
