### PR TITLE
fix: [#304] remove clippy large_stack_arrays workaround (false positive resolved in nightly 1.96.0)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,12 +25,6 @@
 //! - `shared` - Shared modules used across different layers
 //! - `testing` - Testing utilities (unit, integration, and end-to-end)
 
-// False positive: clippy reports large_stack_arrays for vec![] macro with ServiceTopology
-// This is a known upstream issue: https://github.com/rust-lang/rust-clippy/issues/12586
-// Tracking issue: https://github.com/torrust/torrust-tracker-deployer/issues/304
-// See: docs/issues/304-clippy-large-stack-arrays-false-positive.md
-#![allow(clippy::large_stack_arrays)]
-
 pub mod adapters;
 pub mod application;
 pub mod bootstrap;


### PR DESCRIPTION
## Summary

Removes the crate-level `#![allow(clippy::large_stack_arrays)]` workaround from `src/lib.rs` that was added to suppress a clippy false positive.

## Background

Issue #304 tracked a false positive where clippy incorrectly flagged `vec![]` macro usage (heap-allocated) as a large stack array. The upstream bug was reported at https://github.com/rust-lang/rust-clippy/issues/12586.

## Verification

Tested on nightly **1.96.0** (April 7, 2026):

1. Temporarily removed the `#![allow(clippy::large_stack_arrays)]` attribute
2. Ran `cargo clippy --all-targets -- -D clippy::large-stack-arrays` → no errors
3. Ran `cargo clippy --all-targets -- -D clippy::pedantic` → no errors

The false positive no longer occurs. The workaround is no longer needed.

## Changes

- `src/lib.rs`: removed 6 lines (the `#![allow(clippy::large_stack_arrays)]` attribute and its 4 comment lines)

## Related

- Closes #304
- Upstream fix: https://github.com/rust-lang/rust-clippy/pull/12624
- Issue spec: `docs/issues/304-clippy-large-stack-arrays-false-positive.md`