### PR TITLE
docs: [#444] mark RUSTSEC-2026-0097 resolved — rand 0.9.3 already in use

### DIFF
--- a/docs/issues/444-rand-0.9.2-rustsec.md
+++ b/docs/issues/444-rand-0.9.2-rustsec.md
@@ -45,20 +45,16 @@ Expected `cargo audit` output: no finding for `rand 0.9.x`.
 
 ## Steps
 
-- [ ] Run `cargo tree -p rand@0.9.3` — confirm it resolves without error
-- [ ] Run `cargo audit` — confirm no finding for RUSTSEC-2026-0097 on rand 0.9.x
+- [x] Run `cargo tree -p rand@0.9.3` — confirm it resolves without error
+- [x] Run `cargo audit` — confirm no finding for RUSTSEC-2026-0097 on rand 0.9.x
 - [ ] Post a comment on #444 with both outputs
 - [ ] Close #444
 
-## If the audit still reports rand 0.9.2
-
-Run `cargo tree -i rand@0.9.2` to find which crate pins it, then apply
-`cargo update rand` or bump that crate.
-
 ## Outcome
 
-<!-- Fill in after doing the work -->
-
-- Date:
-- Result:
-- Comment/PR:
+- Date: 2026-04-14
+- Result: **Resolved.** `cargo tree -p rand@0.9.3` resolves cleanly to `rand 0.9.3`
+  (patched). `cargo audit` reports only `rand 0.8.5` (tracked separately in #443)
+  — zero finding for `rand 0.9.x`. Issue #444 was opened before `Cargo.lock` was
+  updated to `rand 0.9.3`.
+- Comment/PR: <!-- fill in after posting the comment and closing #444 -->


### PR DESCRIPTION
## Summary

Issue #444 was opened automatically by the cargo-audit CI workflow reporting `rand 0.9.2` as affected by RUSTSEC-2026-0097.

Investigation confirms the issue is already resolved: `Cargo.toml` declares `rand = "0.9"` which resolves to `rand 0.9.3` (the patched release) in `Cargo.lock`. The advisory has zero findings for rand 0.9.x in `cargo audit` output.

## Validation

```
cargo tree -p rand@0.9.3
```
```text
rand v0.9.3
├── rand_chacha v0.9.0
│   ├── ppv-lite86 v0.2.21
│   │   └── zerocopy v0.8.48
│   └── rand_core v0.9.5
│       └── getrandom v0.3.4
├── ...
└── rand_core v0.9.5 (*)
```

```
cargo audit
```
```text
warning: 1 allowed warning found
```
(Only `rand 0.8.5` via `tera` is flagged — tracked separately in #443.)

## Changes

- `docs/issues/444-rand-0.9.2-rustsec.md`: updated spec with investigation results and outcome

Closes #444