### PR TITLE
chore: [#432] upgrade Caddy to 2.11.2 and document CVE analysis

### DIFF
--- a/.github/workflows/docker-security-scan.yml
+++ b/.github/workflows/docker-security-scan.yml
@@ -101,7 +101,7 @@ jobs:
     timeout-minutes: 10
     outputs:
       # JSON array of Docker image references for use in scan matrix
-      # Example: ["torrust/tracker:develop","mysql:8.4","prom/prometheus:v3.11.2","grafana/grafana:13.0.0","caddy:2.10.2"]
+      # Example: ["torrust/tracker:develop","mysql:8.4","prom/prometheus:v3.11.2","grafana/grafana:13.0.0","caddy:2.11.2"]
       images: ${{ steps.extract.outputs.images }}
 
     steps:
@@ -182,7 +182,7 @@ jobs:
               .docker_images.mysql,
               .docker_images.prometheus,
               .docker_images.grafana
-            ] | map(select(. != null)) + ["caddy:2.10.2"]')
+            ] | map(select(. != null)) + ["caddy:2.11.2"]')
 
           echo "Detected images: $images"
           echo "images=$images" >> "$GITHUB_OUTPUT"

--- a/docs/issues/432-caddy-cves.md
+++ b/docs/issues/432-caddy-cves.md
@@ -27,13 +27,13 @@ After PR #436 upgraded Caddy from `2.10` to `2.10.2`:
 
 ## Steps
 
-- [ ] Check the latest Caddy release:
+- [x] Check the latest Caddy release:
       <https://hub.docker.com/_/caddy> and <https://github.com/caddyserver/caddy/releases>
-- [ ] Run Trivy against the latest tag:
+- [x] Run Trivy against the latest tag:
       `trivy image --severity HIGH,CRITICAL caddy:LATEST_TAG`
-- [ ] Compare results against the 2.10.2 baseline in
+- [x] Compare results against the 2.10.2 baseline in
       `docs/security/docker/scans/caddy.md`
-- [ ] **If CRITICALs are cleared (or HIGH count drops meaningfully)**: update
+- [x] **If CRITICALs are cleared (or HIGH count drops meaningfully)**: update
       `templates/docker-compose/docker-compose.yml.tera` and the CI scan matrix;
       update the scan doc; post results comment; close #432
 - [ ] **If CRITICALs remain**: post comment documenting which CVEs remain and why
@@ -41,10 +41,35 @@ After PR #436 upgraded Caddy from `2.10` to `2.10.2`:
 
 ## Outcome
 
-<!-- Fill in after doing the work -->
+- Date: 2026-04-15
+- Latest Caddy tag tested: `2.11.2` (released 2026-04-14)
+- Decision: **upgrade to `caddy:2.11.2`** — HIGH count dropped meaningfully (14→10), CRITICAL halved (4→2)
+- Action: updated `templates/docker-compose/docker-compose.yml.tera` and CI scan matrix
+- Issue: **left open** — 2 CRITICAL CVEs remain in upstream binary dependencies
+- PR: opened against `main` on branch `432-caddy-cves`
 
-- Date:
-- Latest Caddy tag tested:
-- Findings (HIGH / CRITICAL):
-- Decision: upgrade / accept risk / leave open
-- Comment/PR:
+### Scan details — `caddy:2.11.2` (Trivy v0.69.3, 2026-04-15)
+
+**Version comparison:**
+
+| Version  | HIGH | CRITICAL |
+| -------- | ---- | -------- |
+| `2.10`   | 18   | 6        |
+| `2.10.2` | 14   | 4        |
+| `2.11.2` | 10   | 2        |
+
+**Target breakdown:**
+
+| Target         | HIGH | CRITICAL |
+| -------------- | ---- | -------- |
+| caddy (alpine) | 3    | 0        |
+| usr/bin/caddy  | 7    | 2        |
+
+**Remaining CRITICAL CVEs (upstream binary, cannot be fixed without Caddy release):**
+
+| CVE            | Library                | Fix    | Notes                                                      |
+| -------------- | ---------------------- | ------ | ---------------------------------------------------------- |
+| CVE-2026-30836 | smallstep/certificates | 0.30.0 | Unauthenticated SCEP cert issuance                         |
+| CVE-2026-33186 | google.golang.org/grpc | 1.79.3 | Authorization bypass via HTTP/2 path ⚠️ network-accessible |
+
+**Revisit**: when Caddy ships updated grpc-go (≥1.79.3) and smallstep/certificates (≥0.30.0).

--- a/docs/security/docker/scans/README.md
+++ b/docs/security/docker/scans/README.md
@@ -10,7 +10,7 @@ This directory contains historical security scan results for Docker images used 
 | `torrust/tracker-backup`               | trixie  | 6    | 0        | ℹ️ Remediation no change  | Apr 8, 2026  | [View](torrust-tracker-backup.md)               |
 | `torrust/tracker-ssh-server`           | 3.23.3  | 0    | 0        | ✅ Remediated (vuln scan) | Apr 8, 2026  | [View](torrust-ssh-server.md)                   |
 | `torrust/tracker-provisioned-instance` | 24.04   | 0    | 0        | ✅ Remediated (vuln scan) | Apr 8, 2026  | [View](torrust-tracker-provisioned-instance.md) |
-| `caddy`                                | 2.10.2  | 14   | 4        | ⚠️ Partial remediation    | Apr 8, 2026  | [View](caddy.md)                                |
+| `caddy`                                | 2.11.2  | 10   | 2        | ⚠️ Partial remediation    | Apr 15, 2026 | [View](caddy.md)                                |
 | `prom/prometheus`                      | v3.11.2 | 4    | 0        | ✅ Remediated             | Apr 14, 2026 | [View](prometheus.md)                           |
 | `grafana/grafana`                      | 12.4.2  | 4    | 0        | ⚠️ Partial remediation    | Apr 8, 2026  | [View](grafana.md)                              |
 | `mysql`                                | 8.4     | 7    | 1        | ⚠️ Monitored              | Apr 8, 2026  | [View](mysql.md)                                |

--- a/docs/security/docker/scans/caddy.md
+++ b/docs/security/docker/scans/caddy.md
@@ -1,27 +1,84 @@
 # Caddy Security Scan History
 
-**Image**: `caddy:2.10.2`
+**Image**: `caddy:2.11.2`
 **Purpose**: TLS termination proxy for HTTPS support
 **Documentation**: [Caddy TLS Proxy Evaluation](../../research/caddy-tls-proxy-evaluation/README.md)
 
 ## Current Status
 
-| Version | HIGH | CRITICAL | Status                               | Scan Date   |
-| ------- | ---- | -------- | ------------------------------------ | ----------- |
-| 2.10.2  | 14   | 4        | ⚠️ Partial improvement after upgrade | Apr 8, 2026 |
+| Version | HIGH | CRITICAL | Status                               | Scan Date    |
+| ------- | ---- | -------- | ------------------------------------ | ------------ |
+| 2.11.2  | 10   | 2        | ⚠️ Partial improvement after upgrade | Apr 15, 2026 |
 
-**Deployment Status**: ⚠️ Requires follow-up - upgrading from `2.10` to `2.10.2` reduced findings, but HIGH/CRITICAL issues remain in Caddy binary dependencies
+**Deployment Status**: ⚠️ Requires follow-up — 2 CRITICAL CVEs remain in upstream Caddy binary dependencies (smallstep/certificates, grpc-go). Fixes require upstream Caddy releases.
 
 ## Vulnerability Summary
 
-The Caddy 2.10 image has:
+The Caddy 2.11.2 image has:
 
-- **Alpine base image**: Clean (0 vulnerabilities)
-- **Caddy binary (Go)**: 4 vulnerabilities in dependencies (not Caddy core)
+- **Alpine base image**: 3 HIGH, 0 CRITICAL (libcrypto3/libssl3, zlib — fixed versions available)
+- **Caddy binary (Go)**: 7 HIGH, 2 CRITICAL in dependencies (not Caddy core)
 
-All vulnerabilities have fixed versions available upstream and are expected to be resolved in the next Caddy release.
+The 2 CRITICAL CVEs are in upstream Caddy binary dependencies and require Caddy to update its vendored modules.
 
 ## Scan History
+
+### April 15, 2026 - Remediation Pass 2 (Issue #432)
+
+**Scanner**: Trivy v0.69.3
+**Scan Mode**: `--scanners vuln --severity HIGH,CRITICAL`
+**Image**: `caddy:2.11.2`
+**Status**: ⚠️ **12 vulnerabilities** (10 HIGH, 2 CRITICAL)
+
+#### Summary
+
+Upgraded Caddy from `2.10.2` to `2.11.2` (latest as of 2026-04-14). Meaningful reduction in findings but 2 CRITICAL CVEs remain in upstream binary dependencies.
+
+Vulnerability comparison:
+
+| Version  | HIGH | CRITICAL |
+| -------- | ---- | -------- |
+| `2.10`   | 18   | 6        |
+| `2.10.2` | 14   | 4        |
+| `2.11.2` | 10   | 2        |
+
+Issue left open — CRITICALs not fully cleared.
+
+#### Target Breakdown (`2.11.2`)
+
+| Target         | Type     | HIGH | CRITICAL |
+| -------------- | -------- | ---- | -------- |
+| caddy (alpine) | alpine   | 3    | 0        |
+| usr/bin/caddy  | gobinary | 7    | 2        |
+
+#### CVE Details
+
+**Alpine OS layer:**
+
+| CVE            | Library             | Severity | Fixed In | Notes                      |
+| -------------- | ------------------- | -------- | -------- | -------------------------- |
+| CVE-2026-28390 | libcrypto3, libssl3 | HIGH     | 3.5.6-r0 | OpenSSL DoS via NULL deref |
+| CVE-2026-22184 | zlib                | HIGH     | 1.3.2-r0 | Buffer overflow in untgz   |
+
+**Caddy binary (Go):**
+
+| CVE            | Library                | Severity | Fixed In      | Notes                                       |
+| -------------- | ---------------------- | -------- | ------------- | ------------------------------------------- |
+| CVE-2026-34986 | go-jose/go-jose v3+v4  | HIGH     | 3.0.5 / 4.1.4 | DoS via crafted JWE                         |
+| CVE-2026-30836 | smallstep/certificates | CRITICAL | 0.30.0        | Unauthenticated SCEP cert issuance          |
+| CVE-2026-39883 | otel/sdk               | HIGH     | 1.43.0        | Local PATH hijack (no remote path)          |
+| CVE-2026-33186 | google.golang.org/grpc | CRITICAL | 1.79.3        | Authorization bypass via HTTP/2 path        |
+| CVE-2026-25679 | stdlib                 | HIGH     | 1.26.1        | Incorrect IPv6 parsing in net/url           |
+| CVE-2026-27137 | stdlib                 | HIGH     | 1.26.1        | Email constraint enforcement in crypto/x509 |
+| CVE-2026-32280 | stdlib                 | HIGH     | 1.26.2        | Excessive work during chain building        |
+| CVE-2026-32282 | stdlib                 | HIGH     | 1.26.2        | Root.Chmod follows symlinks out of root     |
+
+**Overall risk**: The 2 CRITICAL CVEs (CVE-2026-30836, CVE-2026-33186) are in upstream
+Caddy binary dependencies and require a new Caddy release to fix. CVE-2026-33186
+(gRPC authorization bypass) has a network-accessible attack path. Revisit when
+Caddy ships the updated grpc-go and smallstep dependencies.
+
+---
 
 ### April 8, 2026 - Remediation Pass 1 (Issue #428)
 
@@ -85,7 +142,7 @@ Remaining issues are in upstream Caddy binary dependencies and require vendor/up
 ## How to Rescan
 
 ```bash
-trivy image --severity HIGH,CRITICAL caddy:2.10.2
+trivy image --severity HIGH,CRITICAL caddy:2.11.2
 ```
 
 ## Security Advisories

--- a/project-words.txt
+++ b/project-words.txt
@@ -440,6 +440,7 @@ sandboxed
 sarif
 sarifs
 scannability
+SCEP
 schemafile
 schemars
 scriptable

--- a/templates/docker-compose/docker-compose.yml.tera
+++ b/templates/docker-compose/docker-compose.yml.tera
@@ -52,7 +52,7 @@ services:
   # Placed first as it's the entry point for HTTPS traffic
   caddy:
     <<: *defaults
-    image: caddy:2.10.2
+    image: caddy:2.11.2
     container_name: caddy
     # NOTE: No UFW firewall rule needed for these ports!
     # Docker-published ports bypass iptables/UFW rules entirely.


### PR DESCRIPTION
## Summary

Upgrades Caddy from `2.10.2` to `2.11.2` (latest as of 2026-04-14). Meaningful reduction in vulnerabilities but 2 CRITICAL CVEs remain in upstream binary dependencies — issue left open for revisit.

Related to #432

## Changes

- `templates/docker-compose/docker-compose.yml.tera`: bump Caddy tag `2.10.2` → `2.11.2`
- `.github/workflows/docker-security-scan.yml`: update scan matrix and example comment
- `docs/security/docker/scans/caddy.md`: update header, current status, add Apr 15 scan history entry
- `docs/security/docker/scans/README.md`: update Caddy row
- `docs/issues/432-caddy-cves.md`: fill in Outcome section, check steps
- `project-words.txt`: add `SCEP`

## Scan Results

### Version Comparison

| Version  | HIGH | CRITICAL |
| -------- | ---- | -------- |
| `2.10`   | 18   | 6        |
| `2.10.2` | 14   | 4        |
| `2.11.2` | 10   | 2        |

### Remaining CRITICAL CVEs in 2.11.2 (upstream binary, cannot be fixed without a Caddy release)

| CVE            | Library                | Fix     | Notes                                               |
| -------------- | ---------------------- | ------- | --------------------------------------------------- |
| CVE-2026-30836 | smallstep/certificates | 0.30.0  | Unauthenticated SCEP cert issuance                  |
| CVE-2026-33186 | google.golang.org/grpc | 1.79.3  | Authorization bypass via HTTP/2 path ⚠️ network-accessible |

Issue #432 left open — will revisit when Caddy ships updated grpc-go (≥1.79.3) and smallstep/certificates (≥0.30.0).