### PR TITLE
docs: [#435] document mysql:8.4 CVE analysis and accepted risk

### DIFF
--- a/docs/issues/435-mysql-cves.md
+++ b/docs/issues/435-mysql-cves.md
@@ -24,25 +24,24 @@ the best available option.
 
 ## Steps
 
-- [ ] Pull and scan the current floating tag:
+- [x] Pull and scan the current floating tag:
       `docker pull mysql:8.4 && trivy image --severity HIGH,CRITICAL mysql:8.4`
-- [ ] Check which patch the floating tag currently resolves to:
+- [x] Check which patch the floating tag currently resolves to:
       `docker inspect mysql:8.4 | grep -i version`
-- [ ] Compare results against the 8.4.8 baseline in
+- [x] Compare results against the 8.4.8 baseline in
       `docs/security/docker/scans/mysql.md`
-- [ ] Check if `mysql:9.x` is now a viable option for the deployer (compatibility,
+- [x] Check if `mysql:9.x` is now a viable option for the deployer (compatibility,
       LTS status):
       <https://hub.docker.com/_/mysql>
 - [ ] **If CVE count has dropped**: update the scan doc; post comment; close #435
-- [ ] **If still 7 HIGH / 1 CRITICAL with no viable upgrade path**: post comment
+- [x] **If still 7 HIGH / 1 CRITICAL with no viable upgrade path**: post comment
       documenting accepted risk (helper components, not MySQL core); close #435
 
 ## Outcome
 
-<!-- Fill in after doing the work -->
-
-- Date:
-- Floating tag resolves to:
-- Findings (HIGH / CRITICAL):
-- Decision: accepted risk / upgrade to mysql:9.x
-- Comment/PR:
+- Date: Apr 15, 2026
+- Floating tag resolves to: `8.4.8` (unchanged from Apr 8 baseline)
+- Previous findings (Apr 8, HIGH / CRITICAL): 7 HIGH / 1 CRITICAL
+- Current findings (Apr 15, HIGH / CRITICAL): 9 HIGH / 1 CRITICAL (Trivy DB update; same image digest)
+- mysql:9.6 (latest Innovation Release): identical CVE profile — 9 HIGH / 1 CRITICAL
+- Decision: **accepted risk** — all CVEs in `gosu` helper binary and MySQL Shell Python tools, not MySQL Server core. No viable upgrade path. Requires MySQL upstream to ship updated `gosu` on Go ≥ 1.24.13.

--- a/docs/security/docker/scans/README.md
+++ b/docs/security/docker/scans/README.md
@@ -13,7 +13,7 @@ This directory contains historical security scan results for Docker images used 
 | `caddy`                                | 2.11.2  | 10   | 2        | ⚠️ Partial remediation    | Apr 15, 2026 | [View](caddy.md)                                |
 | `prom/prometheus`                      | v3.11.2 | 4    | 0        | ✅ Remediated             | Apr 14, 2026 | [View](prometheus.md)                           |
 | `grafana/grafana`                      | 12.4.2  | 4    | 0        | ⚠️ Partial remediation    | Apr 8, 2026  | [View](grafana.md)                              |
-| `mysql`                                | 8.4     | 7    | 1        | ⚠️ Monitored              | Apr 8, 2026  | [View](mysql.md)                                |
+| `mysql`                                | 8.4     | 9    | 1        | ⚠️ Accepted risk (gosu)   | Apr 15, 2026 | [View](mysql.md)                                |
 
 **Overall Status**: ⚠️ **CVE database update detected** - Most images still show increased vulnerability counts from previous scans (Feb-Dec 2025). Deployer has a first remediation pass applied (49 HIGH -> 44 HIGH, with 1 CRITICAL still open).
 

--- a/docs/security/docker/scans/mysql.md
+++ b/docs/security/docker/scans/mysql.md
@@ -4,11 +4,77 @@ Security scan history for the `mysql` Docker image.
 
 ## Current Status
 
-| Version | HIGH | CRITICAL | Status                               | Last Scan   | Support EOL  |
-| ------- | ---- | -------- | ------------------------------------ | ----------- | ------------ |
-| 8.4     | 7    | 1        | ⚠️ Monitored (no safer easy upgrade) | Apr 8, 2026 | Apr 30, 2032 |
+| Version | HIGH | CRITICAL | Status                   | Last Scan    | Support EOL  |
+| ------- | ---- | -------- | ------------------------ | ------------ | ------------ |
+| 8.4     | 9    | 1        | ⚠️ Accepted risk (gosu)  | Apr 15, 2026 | Apr 30, 2032 |
 
 ## Scan History
+
+### April 15, 2026 - Remediation Pass 2 / Accepted Risk (Issue #435)
+
+**Image**: `mysql:8.4` (resolves to `8.4.8`)
+**Trivy Version**: 0.69.3
+**Scan Mode**: `--scanners vuln --severity HIGH,CRITICAL`
+**Status**: ⚠️ **10 vulnerabilities** (9 HIGH, 1 CRITICAL)
+
+#### Summary
+
+Floating tag still resolves to `8.4.8` (unchanged from Apr 8 baseline). Vulnerability count
+increased from 7 HIGH + 1 CRITICAL to 9 HIGH + 1 CRITICAL due to Trivy DB updates only;
+no new MySQL release shipped.
+
+A comparison scan of `mysql:9.6` (latest Innovation Release, shipped 2026-04-14) shows an
+**identical CVE profile** — same `gosu v1.24.6` Go binary and same Python packages:
+
+| Version   | HIGH | CRITICAL | Notes                              |
+| --------- | ---- | -------- | ---------------------------------- |
+| `8.4.8`   | 9    | 1        | LTS, support EOL Apr 2032          |
+| `9.6`     | 9    | 1        | Innovation Release, shorter lifecycle |
+
+All CVEs are in helper components only:
+
+| Target                           | HIGH | CRITICAL |
+| -------------------------------- | ---- | -------- |
+| `mysql:8.4` (oracle 9.7)         | 0    | 0        |
+| Python packages (mysqlsh)        | 2    | 0        |
+| `usr/local/bin/gosu`             | 7    | 1        |
+| **Total**                        | **9** | **1**   |
+
+**CVE details — Python packages (`cryptography 45.0.7`, `pyOpenSSL 25.1.0`):**
+
+| CVE            | Library      | Severity | Status | Fixed Version | Title                                         |
+| -------------- | ------------ | -------- | ------ | ------------- | --------------------------------------------- |
+| CVE-2026-26007 | cryptography | HIGH     | fixed  | 46.0.5        | Subgroup attack due to missing SECT validation |
+| CVE-2026-27459 | pyOpenSSL    | HIGH     | fixed  | 26.0.0        | DTLS cookie callback buffer overflow           |
+
+**CVE details — `gosu` (`stdlib v1.24.6`):**
+
+| CVE            | Severity | Status | Fixed Version        | Title                                                        |
+| -------------- | -------- | ------ | -------------------- | ------------------------------------------------------------ |
+| CVE-2025-68121 | CRITICAL | fixed  | 1.24.13, 1.25.7      | crypto/tls: Incorrect certificate validation (TLS resumption) |
+| CVE-2025-58183 | HIGH     | fixed  | 1.24.8, 1.25.2       | archive/tar: Unbounded allocation in GNU sparse map          |
+| CVE-2025-61726 | HIGH     | fixed  | 1.24.12, 1.25.6      | net/url: Memory exhaustion in query parameter parsing        |
+| CVE-2025-61728 | HIGH     | fixed  | 1.24.12, 1.25.6      | archive/zip: Excessive CPU - building archive index          |
+| CVE-2025-61729 | HIGH     | fixed  | 1.24.11, 1.25.5      | crypto/x509: DoS via excessive resource consumption          |
+| CVE-2026-25679 | HIGH     | fixed  | 1.25.8, 1.26.1       | net/url: Incorrect parsing of IPv6 host literals             |
+| CVE-2026-32280 | HIGH     | fixed  | 1.25.9, 1.26.2       | chain building: unbounded work amount                        |
+| CVE-2026-32282 | HIGH     | fixed  | 1.25.9, 1.26.2       | internal/syscall/unix: Root.Chmod can follow symlinks        |
+
+#### Decision
+
+**Accepted risk — close issue #435.**
+
+- No viable upgrade path: `mysql:9.6` (latest) has an identical CVE profile
+- All CVEs are in `gosu` (process privilege helper) and MySQL Shell Python packages —
+  **not MySQL Server itself**
+- The CRITICAL (CVE-2025-68121, crypto/tls cert validation) is in `gosu`, not in any
+  MySQL network-facing code path
+- `mysql:8.4` remains the correct choice: LTS with support until Apr 30, 2032
+- Fix requires MySQL upstream to release a new image with `gosu` rebuilt on Go ≥ 1.24.13
+
+**Revisit**: When MySQL upstream ships `8.4.9` or later with updated `gosu`.
+
+---
 
 ### April 8, 2026 - Remediation Pass 1 (Issue #428)
 

--- a/docs/security/docker/scans/mysql.md
+++ b/docs/security/docker/scans/mysql.md
@@ -4,9 +4,9 @@ Security scan history for the `mysql` Docker image.
 
 ## Current Status
 
-| Version | HIGH | CRITICAL | Status                   | Last Scan    | Support EOL  |
-| ------- | ---- | -------- | ------------------------ | ------------ | ------------ |
-| 8.4     | 9    | 1        | ⚠️ Accepted risk (gosu)  | Apr 15, 2026 | Apr 30, 2032 |
+| Version | HIGH | CRITICAL | Status                  | Last Scan    | Support EOL  |
+| ------- | ---- | -------- | ----------------------- | ------------ | ------------ |
+| 8.4     | 9    | 1        | ⚠️ Accepted risk (gosu) | Apr 15, 2026 | Apr 30, 2032 |
 
 ## Scan History
 
@@ -26,39 +26,39 @@ no new MySQL release shipped.
 A comparison scan of `mysql:9.6` (latest Innovation Release, shipped 2026-04-14) shows an
 **identical CVE profile** — same `gosu v1.24.6` Go binary and same Python packages:
 
-| Version   | HIGH | CRITICAL | Notes                              |
-| --------- | ---- | -------- | ---------------------------------- |
-| `8.4.8`   | 9    | 1        | LTS, support EOL Apr 2032          |
-| `9.6`     | 9    | 1        | Innovation Release, shorter lifecycle |
+| Version | HIGH | CRITICAL | Notes                                 |
+| ------- | ---- | -------- | ------------------------------------- |
+| `8.4.8` | 9    | 1        | LTS, support EOL Apr 2032             |
+| `9.6`   | 9    | 1        | Innovation Release, shorter lifecycle |
 
 All CVEs are in helper components only:
 
-| Target                           | HIGH | CRITICAL |
-| -------------------------------- | ---- | -------- |
-| `mysql:8.4` (oracle 9.7)         | 0    | 0        |
-| Python packages (mysqlsh)        | 2    | 0        |
-| `usr/local/bin/gosu`             | 7    | 1        |
-| **Total**                        | **9** | **1**   |
+| Target                    | HIGH  | CRITICAL |
+| ------------------------- | ----- | -------- |
+| `mysql:8.4` (oracle 9.7)  | 0     | 0        |
+| Python packages (mysqlsh) | 2     | 0        |
+| `usr/local/bin/gosu`      | 7     | 1        |
+| **Total**                 | **9** | **1**    |
 
 **CVE details — Python packages (`cryptography 45.0.7`, `pyOpenSSL 25.1.0`):**
 
-| CVE            | Library      | Severity | Status | Fixed Version | Title                                         |
-| -------------- | ------------ | -------- | ------ | ------------- | --------------------------------------------- |
+| CVE            | Library      | Severity | Status | Fixed Version | Title                                          |
+| -------------- | ------------ | -------- | ------ | ------------- | ---------------------------------------------- |
 | CVE-2026-26007 | cryptography | HIGH     | fixed  | 46.0.5        | Subgroup attack due to missing SECT validation |
 | CVE-2026-27459 | pyOpenSSL    | HIGH     | fixed  | 26.0.0        | DTLS cookie callback buffer overflow           |
 
 **CVE details — `gosu` (`stdlib v1.24.6`):**
 
-| CVE            | Severity | Status | Fixed Version        | Title                                                        |
-| -------------- | -------- | ------ | -------------------- | ------------------------------------------------------------ |
-| CVE-2025-68121 | CRITICAL | fixed  | 1.24.13, 1.25.7      | crypto/tls: Incorrect certificate validation (TLS resumption) |
-| CVE-2025-58183 | HIGH     | fixed  | 1.24.8, 1.25.2       | archive/tar: Unbounded allocation in GNU sparse map          |
-| CVE-2025-61726 | HIGH     | fixed  | 1.24.12, 1.25.6      | net/url: Memory exhaustion in query parameter parsing        |
-| CVE-2025-61728 | HIGH     | fixed  | 1.24.12, 1.25.6      | archive/zip: Excessive CPU - building archive index          |
-| CVE-2025-61729 | HIGH     | fixed  | 1.24.11, 1.25.5      | crypto/x509: DoS via excessive resource consumption          |
-| CVE-2026-25679 | HIGH     | fixed  | 1.25.8, 1.26.1       | net/url: Incorrect parsing of IPv6 host literals             |
-| CVE-2026-32280 | HIGH     | fixed  | 1.25.9, 1.26.2       | chain building: unbounded work amount                        |
-| CVE-2026-32282 | HIGH     | fixed  | 1.25.9, 1.26.2       | internal/syscall/unix: Root.Chmod can follow symlinks        |
+| CVE            | Severity | Status | Fixed Version   | Title                                                         |
+| -------------- | -------- | ------ | --------------- | ------------------------------------------------------------- |
+| CVE-2025-68121 | CRITICAL | fixed  | 1.24.13, 1.25.7 | crypto/tls: Incorrect certificate validation (TLS resumption) |
+| CVE-2025-58183 | HIGH     | fixed  | 1.24.8, 1.25.2  | archive/tar: Unbounded allocation in GNU sparse map           |
+| CVE-2025-61726 | HIGH     | fixed  | 1.24.12, 1.25.6 | net/url: Memory exhaustion in query parameter parsing         |
+| CVE-2025-61728 | HIGH     | fixed  | 1.24.12, 1.25.6 | archive/zip: Excessive CPU - building archive index           |
+| CVE-2025-61729 | HIGH     | fixed  | 1.24.11, 1.25.5 | crypto/x509: DoS via excessive resource consumption           |
+| CVE-2026-25679 | HIGH     | fixed  | 1.25.8, 1.26.1  | net/url: Incorrect parsing of IPv6 host literals              |
+| CVE-2026-32280 | HIGH     | fixed  | 1.25.9, 1.26.2  | chain building: unbounded work amount                         |
+| CVE-2026-32282 | HIGH     | fixed  | 1.25.9, 1.26.2  | internal/syscall/unix: Root.Chmod can follow symlinks         |
 
 #### Decision
 

--- a/project-words.txt
+++ b/project-words.txt
@@ -441,6 +441,9 @@ sarif
 sarifs
 scannability
 SCEP
+DTLS
+mysqlsh
+syscall
 schemafile
 schemars
 scriptable


### PR DESCRIPTION
## Summary

Re-scan of `mysql:8.4` as requested in issue #435.

**No code change** — `mysql:8.4` is a floating tag (no version constant to update).

## Findings (Apr 15, 2026 — Trivy v0.69.3)

| Image       | Resolves to | HIGH | CRITICAL |
|-------------|-------------|------|----------|
| `mysql:8.4` | `8.4.8`     | 9    | 1        |
| `mysql:9.6` | `9.6.0`     | 9    | 1        |

The floating tag still resolves to **8.4.8** (same digest as Apr 8 baseline). The CVE count
moved from 7H+1C → 9H+1C due to Trivy DB updates only; no new MySQL release was shipped.

All vulnerabilities are in **helper components only** — not MySQL Server core:

- `gosu v1.24.6` (Go stdlib): 7 HIGH + 1 CRITICAL
  - CRITICAL: CVE-2025-68121 — crypto/tls cert validation during TLS resumption (fix: Go ≥ 1.24.13)
- MySQL Shell Python packages: 2 HIGH (`cryptography`, `pyOpenSSL`)

## mysql:9.x Assessment

`mysql:9.6` (latest Innovation Release, 2026-04-14) has an **identical CVE profile**: same
`gosu v1.24.6` and same Python packages → no security benefit to switching. Additionally,
`mysql:9.x` is a non-LTS Innovation Release with a shorter lifecycle vs `mysql:8.4` (LTS until Apr 2032).

## Decision

**Accepted risk — close #435.**

- No viable upgrade path exists (same CVEs across all tags)
- CVEs are in `gosu` helper and mysqlsh tools, not MySQL server
- Fix requires MySQL upstream to ship new image with `gosu` rebuilt on Go ≥ 1.24.13
- Revisit when `mysql:8.4.9` or later is released

## Changes

- `docs/security/docker/scans/mysql.md` — new Remediation Pass 2 history entry with full CVE tables
- `docs/security/docker/scans/README.md` — updated mysql row (9H+1C, Apr 15)
- `docs/issues/435-mysql-cves.md` — checked off steps, filled Outcome section
- `project-words.txt` — added `DTLS`, `mysqlsh`, `syscall`

Closes #435