### PR TITLE
docs: [#431] document backup image CVE analysis and accepted risk

### DIFF
--- a/docs/issues/431-backup-cves.md
+++ b/docs/issues/431-backup-cves.md
@@ -29,25 +29,24 @@ All 6 HIGH are Debian 13.4 (trixie) base package CVEs.
 
 ## Steps
 
-- [ ] Rebuild the image from scratch:
+- [x] Rebuild the image from scratch:
       `docker build --no-cache -t torrust/tracker-backup:local docker/backup/`
-- [ ] Re-scan: `trivy image --severity HIGH,CRITICAL torrust/tracker-backup:local`
-- [ ] Compare against the pass-1 baseline in
+- [x] Re-scan: `trivy image --severity HIGH,CRITICAL torrust/tracker-backup:local`
+- [x] Compare against the pass-1 baseline in
       `docs/security/docker/scans/torrust-tracker-backup.md`
-- [ ] For each remaining CVE, check fix availability:
+- [x] For each remaining CVE, check fix availability:
       <https://security-tracker.debian.org/tracker/>
-- [ ] Update `docs/security/docker/scans/torrust-tracker-backup.md` with the new
+- [x] Update `docs/security/docker/scans/torrust-tracker-backup.md` with the new
       scan results
 - [ ] **If HIGH count dropped**: post comment with before/after results; close #431
-- [ ] **If no change**: post comment documenting that Debian upstream has not yet
+- [x] **If no change**: post comment documenting that Debian upstream has not yet
       patched these CVEs with a revisit note; close #431
 
 ## Outcome
 
-<!-- Fill in after doing the work -->
-
-- Date:
-- Findings after rebuild (HIGH / CRITICAL):
-- Debian packages patched: yes / no
-- Decision: resolved / accepted risk
-- Comment/PR:
+- Date: Apr 15, 2026
+- Findings after rebuild (HIGH / CRITICAL): 6 HIGH / 0 CRITICAL (unchanged)
+- CVEs: CVE-2025-69720 (ncurses `infocmp`) and CVE-2026-29111 (systemd IPC)
+- Debian packages patched: no — both CVEs are `<no-dsa>` minor issues; fixes only in forky/sid
+- Decision: **accepted risk** — neither CVE is reachable in our container's runtime (no `infocmp` call, no systemd PID 1)
+- Comment/PR: PR #457, comment on #431

--- a/docs/security/docker/scans/README.md
+++ b/docs/security/docker/scans/README.md
@@ -4,16 +4,16 @@ This directory contains historical security scan results for Docker images used 
 
 ## Current Status Summary
 
-| Image                                  | Version | HIGH | CRITICAL | Status                    | Last Scan    | Details                                         |
-| -------------------------------------- | ------- | ---- | -------- | ------------------------- | ------------ | ----------------------------------------------- |
-| `torrust/tracker-deployer`             | trixie  | 44   | 1        | ⚠️ Partial remediation    | Apr 8, 2026  | [View](torrust-tracker-deployer.md)             |
-| `torrust/tracker-backup`               | trixie  | 6    | 0        | ℹ️ Remediation no change  | Apr 8, 2026  | [View](torrust-tracker-backup.md)               |
-| `torrust/tracker-ssh-server`           | 3.23.3  | 0    | 0        | ✅ Remediated (vuln scan) | Apr 8, 2026  | [View](torrust-ssh-server.md)                   |
-| `torrust/tracker-provisioned-instance` | 24.04   | 0    | 0        | ✅ Remediated (vuln scan) | Apr 8, 2026  | [View](torrust-tracker-provisioned-instance.md) |
-| `caddy`                                | 2.11.2  | 10   | 2        | ⚠️ Partial remediation    | Apr 15, 2026 | [View](caddy.md)                                |
-| `prom/prometheus`                      | v3.11.2 | 4    | 0        | ✅ Remediated             | Apr 14, 2026 | [View](prometheus.md)                           |
-| `grafana/grafana`                      | 12.4.2  | 4    | 0        | ⚠️ Partial remediation    | Apr 8, 2026  | [View](grafana.md)                              |
-| `mysql`                                | 8.4     | 9    | 1        | ⚠️ Accepted risk (gosu)   | Apr 15, 2026 | [View](mysql.md)                                |
+| Image                                  | Version | HIGH | CRITICAL | Status                               | Last Scan    | Details                                         |
+| -------------------------------------- | ------- | ---- | -------- | ------------------------------------ | ------------ | ----------------------------------------------- |
+| `torrust/tracker-deployer`             | trixie  | 44   | 1        | ⚠️ Partial remediation               | Apr 8, 2026  | [View](torrust-tracker-deployer.md)             |
+| `torrust/tracker-backup`               | trixie  | 6    | 0        | ⚠️ Accepted risk (Debian `<no-dsa>`) | Apr 15, 2026 | [View](torrust-tracker-backup.md)               |
+| `torrust/tracker-ssh-server`           | 3.23.3  | 0    | 0        | ✅ Remediated (vuln scan)            | Apr 8, 2026  | [View](torrust-ssh-server.md)                   |
+| `torrust/tracker-provisioned-instance` | 24.04   | 0    | 0        | ✅ Remediated (vuln scan)            | Apr 8, 2026  | [View](torrust-tracker-provisioned-instance.md) |
+| `caddy`                                | 2.11.2  | 10   | 2        | ⚠️ Partial remediation               | Apr 15, 2026 | [View](caddy.md)                                |
+| `prom/prometheus`                      | v3.11.2 | 4    | 0        | ✅ Remediated                        | Apr 14, 2026 | [View](prometheus.md)                           |
+| `grafana/grafana`                      | 12.4.2  | 4    | 0        | ⚠️ Partial remediation               | Apr 8, 2026  | [View](grafana.md)                              |
+| `mysql`                                | 8.4     | 9    | 1        | ⚠️ Accepted risk (gosu)              | Apr 15, 2026 | [View](mysql.md)                                |
 
 **Overall Status**: ⚠️ **CVE database update detected** - Most images still show increased vulnerability counts from previous scans (Feb-Dec 2025). Deployer has a first remediation pass applied (49 HIGH -> 44 HIGH, with 1 CRITICAL still open).
 

--- a/docs/security/docker/scans/torrust-tracker-backup.md
+++ b/docs/security/docker/scans/torrust-tracker-backup.md
@@ -4,9 +4,9 @@ Security scan history for the `torrust/tracker-backup` Docker image.
 
 ## Current Status
 
-| Version | HIGH | CRITICAL | Status               | Last Scan   |
-| ------- | ---- | -------- | -------------------- | ----------- |
-| trixie  | 6    | 0        | ℹ️ Base OS Monitored | Apr 8, 2026 |
+| Version | HIGH | CRITICAL | Status                               | Last Scan    |
+| ------- | ---- | -------- | ------------------------------------ | ------------ |
+| trixie  | 6    | 0        | ⚠️ Accepted risk (Debian `<no-dsa>`) | Apr 15, 2026 |
 
 ## Build & Scan Commands
 
@@ -23,6 +23,56 @@ trivy image --severity HIGH,CRITICAL torrust/tracker-backup:local
 ```
 
 ## Scan History
+
+### April 15, 2026 - Remediation Pass 2 / Accepted Risk (Issue #431)
+
+**Image**: `torrust/tracker-backup:local`
+**Trivy Version**: 0.69.3
+**Scan Mode**: `--scanners vuln --severity HIGH,CRITICAL`
+**Base OS**: Debian 13.4 (trixie-slim)
+**Status**: ⚠️ **No change** — 6 HIGH, 0 CRITICAL
+
+#### Summary
+
+Image rebuilt from scratch with `--no-cache`. All Debian packages updated to latest trixie
+repository state. Vulnerability count unchanged: **6 HIGH, 0 CRITICAL**.
+
+| Target                                       | HIGH | CRITICAL |
+| -------------------------------------------- | ---- | -------- |
+| `torrust/tracker-backup:local` (debian 13.4) | 6    | 0        |
+
+| CVE            | Library                                           | Severity | Status   | Fixed Version | Title                                                     |
+| -------------- | ------------------------------------------------- | -------- | -------- | ------------- | --------------------------------------------------------- |
+| CVE-2025-69720 | libncurses6, libtinfo6, ncurses-base, ncurses-bin | HIGH     | affected | —             | ncurses: Buffer overflow in `infocmp` CLI tool            |
+| CVE-2026-29111 | libsystemd0, libudev1                             | HIGH     | affected | —             | systemd: Assert/freeze via spurious unprivileged IPC call |
+
+#### Debian Security Tracker Status
+
+Both CVEs confirmed as `<no-dsa>` (minor issue) for trixie — Debian Security Team will not
+issue a DSA for stable trixie:
+
+- **CVE-2025-69720**: Fixed only in `forky/sid` (`ncurses 6.6+20251231-1`). Affects the
+  `infocmp` CLI tool (`progs/infocmp.c`) — **not the ncurses library itself**. Our backup
+  container never invokes `infocmp`.
+- **CVE-2026-29111**: Fixed only in `forky/sid` (`systemd 260.1-1`). Affects systemd when
+  running as PID 1 and receiving a spurious unprivileged IPC call. Our container runs a bash
+  script as entrypoint — **systemd is not PID 1**; `libsystemd0`/`libudev1` are installed as
+  transitive dependencies of other packages but the daemon is never started.
+
+#### Decision
+
+**Accepted risk — close issue #431.**
+
+- No fixes available in Debian trixie for either CVE
+- Both CVEs are marked `<no-dsa>` minor issues by Debian Security Team
+- Neither CVE is reachable in our container's runtime behaviour:
+  - `infocmp` is never called
+  - systemd is not running as PID 1
+- The backup container has a minimal footprint, runs non-root, and is not network-accessible
+
+**Revisit**: When Debian trixie backports fixes for `ncurses` or `systemd`.
+
+---
 
 ### April 8, 2026 - Remediation Pass 1 (Issue #428)
 

--- a/project-words.txt
+++ b/project-words.txt
@@ -444,6 +444,12 @@ SCEP
 DTLS
 mysqlsh
 syscall
+infocmp
+libncurses
+libtinfo
+libsystemd
+libudev
+behaviour
 schemafile
 schemars
 scriptable


### PR DESCRIPTION
## Summary

Re-scan of `torrust/tracker-backup:local` as requested in issue #431.

**No code change** — image rebuilt from scratch with `--no-cache` to pick up any available
Debian package updates. Vulnerability count unchanged.

## Findings (Apr 15, 2026 — Trivy v0.69.3)

| Pass     | HIGH | CRITICAL | Notes                          |
|----------|------|----------|--------------------------------|
| Apr 8    | 6    | 0        | Pass 1 baseline                |
| Apr 15   | 6    | 0        | Rebuilt from scratch, no change |

All 6 HIGH are Debian base OS CVEs with no fix available in trixie:

| CVE            | Packages                                           | Status   | Fix in trixie |
|----------------|----------------------------------------------------|----------|---------------|
| CVE-2025-69720 | libncurses6, libtinfo6, ncurses-base, ncurses-bin  | affected | None (`<no-dsa>`) |
| CVE-2026-29111 | libsystemd0, libudev1                              | affected | None (`<no-dsa>`) |

## Debian Security Tracker Confirmation

Both CVEs are tagged **`<no-dsa>` (minor issue)** for trixie — Debian Security Team will not
backport fixes to stable trixie. Fixes exist only in `forky/sid` (unstable).

## Risk Assessment

Neither CVE is reachable in our container's runtime:

- **CVE-2025-69720** (ncurses): affects the `infocmp` CLI tool only — not the ncurses library.
  The backup container never calls `infocmp`.
- **CVE-2026-29111** (systemd): affects systemd when running as **PID 1** receiving a spurious
  unprivileged IPC call. Our container runs a bash script — systemd is never started.
  `libsystemd0`/`libudev1` are transitive package dependencies only.

## Decision

**Accepted risk — close #431.**

Revisit when Debian trixie backports a fix for `ncurses` or `systemd`.

## Changes

- `docs/security/docker/scans/torrust-tracker-backup.md` — new Remediation Pass 2 entry with full CVE table and Debian tracker status
- `docs/security/docker/scans/README.md` — updated backup row (Apr 15, accepted risk)
- `docs/issues/431-backup-cves.md` — checked off steps, filled Outcome section
- `project-words.txt` — added `infocmp`, `libncurses`, `libtinfo`, `libsystemd`, `libudev`, `behaviour`

Closes #431