### PR TITLE
docs: [#429] document deployer scan pass-2 - CRITICAL pending OpenTofu upstream

### DIFF
--- a/docs/issues/429-deployer-cves.md
+++ b/docs/issues/429-deployer-cves.md
@@ -33,37 +33,38 @@ Remaining findings split into two areas:
 
 ## Steps
 
-- [ ] Check current OpenTofu version pinned in the Dockerfile:
+- [x] Check current OpenTofu version pinned in the Dockerfile:
       `grep -i opentofu docker/deployer/Dockerfile`
-- [ ] Check latest OpenTofu release:
+- [x] Check latest OpenTofu release:
       <https://github.com/opentofu/opentofu/releases>
-- [ ] Rebuild and re-scan:
+- [x] Rebuild and re-scan:
 
   ```bash
   docker build --no-cache -t torrust/tracker-deployer:local docker/deployer/
   trivy image --severity HIGH,CRITICAL torrust/tracker-deployer:local
   ```
 
-- [ ] Compare against the pass-1 baseline in
+- [x] Compare against the pass-1 baseline in
       `docs/security/docker/scans/torrust-tracker-deployer.md`
-- [ ] For Debian base package CVEs, check fix availability:
+- [x] For Debian base package CVEs, check fix availability:
       <https://security-tracker.debian.org/tracker/>
-- [ ] Update `docs/security/docker/scans/torrust-tracker-deployer.md` with new
+- [x] Update `docs/security/docker/scans/torrust-tracker-deployer.md` with new
       scan results
 - [ ] **If CRITICAL is cleared**: update Dockerfile OpenTofu version; post results
       comment; close #429
 - [ ] **If only Debian packages improved**: post results comment; re-evaluate open
       status
-- [ ] **If no change**: post comment with accepted risk rationale for remaining
+- [x] **If no change**: post comment with accepted risk rationale for remaining
       CVEs; label `accepted-risk`; leave open with revisit note
 
 ## Outcome
 
-<!-- Fill in after doing the work -->
-
-- Date:
-- Current OpenTofu version in Dockerfile:
-- Latest OpenTofu release:
-- Findings after rebuild (HIGH / CRITICAL):
-- Decision: fixed / partial / accepted risk
-- Comment/PR:
+- Date: Apr 15, 2026
+- Current OpenTofu version in Dockerfile: installed via script (no pinned version)
+- Latest OpenTofu release: v1.11.6 (2026-04-08) — installed in rebuilt image
+- Findings after rebuild (HIGH / CRITICAL): 46 HIGH / 1 CRITICAL
+  - Debian OS: 42 HIGH, 0 CRITICAL
+  - `usr/bin/tofu` (v1.11.6): 4 HIGH, 1 CRITICAL
+- Decision: **leave open** — CRITICAL CVE-2026-33186 (grpc-go gRPC auth bypass) remains in tofu binary; requires OpenTofu upstream to bump grpc-go to v1.79.3+
+- Comment/PR: PR #458, comment on #429
+- Revisit: when OpenTofu ships v1.11.7+ or v1.12.x with updated grpc-go dependency

--- a/docs/security/docker/scans/README.md
+++ b/docs/security/docker/scans/README.md
@@ -4,16 +4,16 @@ This directory contains historical security scan results for Docker images used 
 
 ## Current Status Summary
 
-| Image                                  | Version | HIGH | CRITICAL | Status                               | Last Scan    | Details                                         |
-| -------------------------------------- | ------- | ---- | -------- | ------------------------------------ | ------------ | ----------------------------------------------- |
-| `torrust/tracker-deployer`             | trixie  | 44   | 1        | ⚠️ Partial remediation               | Apr 8, 2026  | [View](torrust-tracker-deployer.md)             |
-| `torrust/tracker-backup`               | trixie  | 6    | 0        | ⚠️ Accepted risk (Debian `<no-dsa>`) | Apr 15, 2026 | [View](torrust-tracker-backup.md)               |
-| `torrust/tracker-ssh-server`           | 3.23.3  | 0    | 0        | ✅ Remediated (vuln scan)            | Apr 8, 2026  | [View](torrust-ssh-server.md)                   |
-| `torrust/tracker-provisioned-instance` | 24.04   | 0    | 0        | ✅ Remediated (vuln scan)            | Apr 8, 2026  | [View](torrust-tracker-provisioned-instance.md) |
-| `caddy`                                | 2.11.2  | 10   | 2        | ⚠️ Partial remediation               | Apr 15, 2026 | [View](caddy.md)                                |
-| `prom/prometheus`                      | v3.11.2 | 4    | 0        | ✅ Remediated                        | Apr 14, 2026 | [View](prometheus.md)                           |
-| `grafana/grafana`                      | 12.4.2  | 4    | 0        | ⚠️ Partial remediation               | Apr 8, 2026  | [View](grafana.md)                              |
-| `mysql`                                | 8.4     | 9    | 1        | ⚠️ Accepted risk (gosu)              | Apr 15, 2026 | [View](mysql.md)                                |
+| Image                                  | Version | HIGH | CRITICAL | Status                                 | Last Scan    | Details                                         |
+| -------------------------------------- | ------- | ---- | -------- | -------------------------------------- | ------------ | ----------------------------------------------- |
+| `torrust/tracker-deployer`             | trixie  | 46   | 1        | ⚠️ CRITICAL blocked (OpenTofu grpc-go) | Apr 15, 2026 | [View](torrust-tracker-deployer.md)             |
+| `torrust/tracker-backup`               | trixie  | 6    | 0        | ⚠️ Accepted risk (Debian `<no-dsa>`)   | Apr 15, 2026 | [View](torrust-tracker-backup.md)               |
+| `torrust/tracker-ssh-server`           | 3.23.3  | 0    | 0        | ✅ Remediated (vuln scan)              | Apr 8, 2026  | [View](torrust-ssh-server.md)                   |
+| `torrust/tracker-provisioned-instance` | 24.04   | 0    | 0        | ✅ Remediated (vuln scan)              | Apr 8, 2026  | [View](torrust-tracker-provisioned-instance.md) |
+| `caddy`                                | 2.11.2  | 10   | 2        | ⚠️ Partial remediation                 | Apr 15, 2026 | [View](caddy.md)                                |
+| `prom/prometheus`                      | v3.11.2 | 4    | 0        | ✅ Remediated                          | Apr 14, 2026 | [View](prometheus.md)                           |
+| `grafana/grafana`                      | 12.4.2  | 4    | 0        | ⚠️ Partial remediation                 | Apr 8, 2026  | [View](grafana.md)                              |
+| `mysql`                                | 8.4     | 9    | 1        | ⚠️ Accepted risk (gosu)                | Apr 15, 2026 | [View](mysql.md)                                |
 
 **Overall Status**: ⚠️ **CVE database update detected** - Most images still show increased vulnerability counts from previous scans (Feb-Dec 2025). Deployer has a first remediation pass applied (49 HIGH -> 44 HIGH, with 1 CRITICAL still open).
 

--- a/docs/security/docker/scans/torrust-tracker-deployer.md
+++ b/docs/security/docker/scans/torrust-tracker-deployer.md
@@ -4,9 +4,9 @@ Security scan history for the `torrust/tracker-deployer` Docker image.
 
 ## Current Status
 
-| Version | HIGH | CRITICAL | Status                                     | Last Scan   |
-| ------- | ---- | -------- | ------------------------------------------ | ----------- |
-| trixie  | 44   | 1        | ⚠️ Improved after remediation (still open) | Apr 8, 2026 |
+| Version | HIGH | CRITICAL | Status                                             | Last Scan    |
+| ------- | ---- | -------- | -------------------------------------------------- | ------------ |
+| trixie  | 46   | 1        | ⚠️ CRITICAL blocked on OpenTofu upstream (grpc-go) | Apr 15, 2026 |
 
 ## Build & Scan Commands
 
@@ -23,6 +23,76 @@ trivy image --severity HIGH,CRITICAL torrust/tracker-deployer:local
 ```
 
 ## Scan History
+
+### April 15, 2026 - Remediation Pass 2 (Issue #429)
+
+**Image**: `torrust/tracker-deployer:local`
+**OpenTofu version**: v1.11.6 (latest, released 2026-04-08)
+**Trivy Version**: 0.69.3
+**Scan Mode**: `--scanners vuln --severity HIGH,CRITICAL`
+**Base OS**: Debian 13.4 (trixie)
+**Status**: ⚠️ **1 CRITICAL remains** (blocked on OpenTofu upstream) — 46 HIGH, 1 CRITICAL
+
+#### Summary
+
+Image rebuilt from scratch with `--no-cache`. OpenTofu v1.11.6 (latest) was installed.
+CRITICAL in `usr/bin/tofu` (CVE-2026-33186, grpc-go) **remains unresolved** — needs
+OpenTofu to upgrade `google.golang.org/grpc` to v1.79.3+.
+
+#### Target breakdown
+
+| Target                                         | HIGH   | CRITICAL |
+| ---------------------------------------------- | ------ | -------- |
+| `torrust/tracker-deployer:local` (debian 13.4) | 42     | 0        |
+| `usr/bin/tofu`                                 | 4      | 1        |
+| **Total**                                      | **46** | **1**    |
+
+#### Comparison vs pass 1 (Apr 8)
+
+| Target         | Apr 8 (HIGH / CRITICAL) | Apr 15 (HIGH / CRITICAL) | Delta                                      |
+| -------------- | ----------------------- | ------------------------ | ------------------------------------------ |
+| Debian OS      | 42 / 0                  | 42 / 0                   | no change (same Debian state)              |
+| `usr/bin/tofu` | 2 / 1                   | 4 / 1                    | +2 HIGH (Trivy DB update)                  |
+| **Total**      | **44 / 1**              | **46 / 1**               | **+2 HIGH (Trivy DB), CRITICAL unchanged** |
+
+#### `usr/bin/tofu` CVE details (OpenTofu v1.11.6)
+
+| CVE            | Library                        | Severity | Status | Installed | Fixed  | Title                                           |
+| -------------- | ------------------------------ | -------- | ------ | --------- | ------ | ----------------------------------------------- |
+| CVE-2026-33186 | google.golang.org/grpc         | CRITICAL | fixed  | v1.76.0   | 1.79.3 | gRPC-Go: Authorization bypass via HTTP/2 path   |
+| CVE-2026-34986 | github.com/go-jose/go-jose/v4  | HIGH     | fixed  | v4.1.2    | 4.1.4  | JOSE: DoS via crafted JSON Web Encryption       |
+| CVE-2026-4660  | github.com/hashicorp/go-getter | HIGH     | fixed  | v1.8.2    | 1.8.6  | go-getter: Arbitrary file reads via crafted URL |
+| CVE-2026-24051 | go.opentelemetry.io/otel/sdk   | HIGH     | fixed  | v1.38.0   | 1.40.0 | OTel Go SDK: Arbitrary code execution via PATH  |
+| CVE-2026-39883 | go.opentelemetry.io/otel/sdk   | HIGH     | fixed  | v1.38.0   | 1.43.0 | OTel Go SDK: BSD kenv PATH hijacking            |
+
+All `usr/bin/tofu` CVEs have fixes available in their respective upstream libraries but
+require OpenTofu to update its Go module dependencies and ship a new release.
+
+#### Notable Debian OS CVEs (selected new or notable HIGH, all `affected` / no fix in trixie)
+
+| CVE            | Package        | Title                                                       |
+| -------------- | -------------- | ----------------------------------------------------------- |
+| CVE-2025-13836 | python3.13     | cpython: Excessive read buffering DoS in http.client        |
+| CVE-2025-15366 | python3.13     | cpython: IMAP command injection (`will_not_fix`)            |
+| CVE-2025-15367 | python3.13     | cpython: POP3 command injection (`will_not_fix`)            |
+| CVE-2026-25210 | libexpat1      | libexpat: Integer overflow — data integrity issues          |
+| CVE-2026-29111 | libsystemd0    | systemd: Assert/freeze via spurious IPC (`<no-dsa>`)        |
+| CVE-2026-35385 | openssh-client | OpenSSH: Priv escalation via scp legacy protocol            |
+| CVE-2026-35414 | openssh-client | OpenSSH: Security bypass via authorized_keys principals     |
+| CVE-2026-35535 | sudo           | Sudo: Privilege escalation via failed privilege drop        |
+| CVE-2025-69720 | ncurses        | ncurses: Buffer overflow in `infocmp` CLI tool (`<no-dsa>`) |
+
+#### Decision
+
+**Leave issue #429 open — CRITICAL unresolved.**
+
+- CRITICAL CVE-2026-33186 (grpc-go, gRPC authorization bypass) remains in `usr/bin/tofu` v1.11.6
+- Fix requires OpenTofu to bump `google.golang.org/grpc` to v1.79.3+ and ship a new release
+- Debian OS CVEs are all `affected`/`will_not_fix`/`<no-dsa>` with no trixie backports available
+
+**Revisit**: When OpenTofu releases v1.11.7+ or v1.12.x with updated `grpc-go` dependency.
+
+---
 
 ### April 8, 2026 - Remediation Pass 1 (Issue #428)
 

--- a/project-words.txt
+++ b/project-words.txt
@@ -578,3 +578,7 @@ userinfo
 ключ
 конфиг
 файл
+
+cpython
+kenv
+libexpat


### PR DESCRIPTION
## Summary

Documents Remediation Pass 2 for the `torrust/tracker-deployer` Docker image CVE scan (issue #429).

## Changes

- `docs/security/docker/scans/torrust-tracker-deployer.md` — added Pass 2 scan entry (Apr 15, 2026) with full CVE tables and decision rationale
- `docs/security/docker/scans/README.md` — updated deployer row: 46 HIGH / 1 CRITICAL, Apr 15, 2026
- `docs/issues/429-deployer-cves.md` — checked off completed steps; filled Outcome
- `project-words.txt` — added `cpython`, `kenv`, `libexpat`

## Scan results (Pass 2 — Apr 15, 2026)

Image rebuilt `--no-cache` with OpenTofu v1.11.6 (latest).

| Target | HIGH | CRITICAL |
|--------|------|----------|
| Debian OS (trixie 13.4) | 42 | 0 |
| `usr/bin/tofu` | 4 | 1 |
| **Total** | **46** | **1** |

## Decision

**Issue #429 remains open.**

The CRITICAL CVE-2026-33186 (gRPC-Go authorization bypass via HTTP/2 path validation) is
present in `google.golang.org/grpc v1.76.0` embedded in `usr/bin/tofu`. The fix requires
grpc-go ≥ 1.79.3; OpenTofu v1.11.6 has not yet updated this dependency.

All Debian OS HIGH CVEs are `affected`/`will_not_fix`/`<no-dsa>` with no trixie
backports available — accepted risk (same status as backup/Caddy OS layers).

**Revisit**: when OpenTofu ships v1.11.7+ or v1.12.x with upgraded grpc-go.

Related to #429